### PR TITLE
[DCP Docker Push] Simplify cloudbuild

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -26,4 +26,4 @@ EXPOSE 5000
 
 # Set the entrypoint to the CLI
 ENTRYPOINT ["datacommons", "api"]
-CMD ["--host", "0.0.0.0", "--port", "5000"]
+CMD ["start", "--host", "0.0.0.0", "--port", "5000"]

--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -1,12 +1,16 @@
 steps:
   # Build the container image
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'gcr.io/datcom-ci/datacommons-platform:latest', '-t', 'gcr.io/datcom-ci/datacommons-platform:$COMMIT_SHA', '-f', 'build/Dockerfile', '.']
-  # Push the container image to Container Registry
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'gcr.io/datcom-ci/datacommons-platform:latest']
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'gcr.io/datcom-ci/datacommons-platform:$COMMIT_SHA']
+    args: 
+      - 'build'
+      - '-t'
+      - 'gcr.io/datcom-ci/datacommons-platform:latest'
+      - '-t'
+      - 'gcr.io/datcom-ci/datacommons-platform:$COMMIT_SHA'
+      - '-f'
+      - 'build/Dockerfile'
+      - '.'
+
 images:
   - 'gcr.io/datcom-ci/datacommons-platform:latest'
   - 'gcr.io/datcom-ci/datacommons-platform:$COMMIT_SHA'

--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -4,13 +4,13 @@ steps:
     args: 
       - 'build'
       - '-t'
-      - 'gcr.io/datcom-ci/datacommons-platform:latest'
+      - 'us-docker.pkg.dev/datcom-ci/gcr.io/datacommons-platform:latest'
       - '-t'
-      - 'gcr.io/datcom-ci/datacommons-platform:$COMMIT_SHA'
+      - 'us-docker.pkg.dev/datcom-ci/gcr.io/datacommons-platform:$COMMIT_SHA'
       - '-f'
       - 'build/Dockerfile'
       - '.'
 
 images:
-  - 'gcr.io/datcom-ci/datacommons-platform:latest'
-  - 'gcr.io/datcom-ci/datacommons-platform:$COMMIT_SHA'
+  - 'us-docker.pkg.dev/datcom-ci/gcr.io/datacommons-platform:latest'
+  - 'us-docker.pkg.dev/datcom-ci/gcr.io/datacommons-platform:$COMMIT_SHA'


### PR DESCRIPTION
We do not need the explicit docker push command.
Small simplification.

The plan is to use this cloudbuild.yaml on 2 triggers:
- There is a pubsub that gets periodically triggered to update all our images
- On each PR merge in the datacommonsorg/datacommons repo. 

Also migrates to using the new format for the artifact registry repo path. Verified by running local, see images generated in https://pantheon.corp.google.com/artifacts/docker/datcom-ci/us/gcr.io/datacommons-platform?e=13803378&inv=1&invt=Ab3CEA&mods=-monitoring_api_staging&project=datcom-ci

Adds the "start" command to the command in the docker container as this was ommitted I think by mistake. Im not sure why it worked locally, but the Cloud Run error was clear about missing the start command once deployed!
