### PR TITLE
[DCP - Terraform] Initializes the APIs, Service Account, Cloud Run Service and Spanner Instance and DB.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _override.tf.json
 terraform.rc
 tfplan
 infra/dcp/backend.tf
+.terraform.lock.hcl
 
 # Configuration
 infra/dcp/.env

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,27 @@ node_modules
 .ruff_cache
 .coverage
 htmlcov/
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+crash.log.*
+*.tfvars
+*.tfvars.json
+override.tf
+override.tf.json
+_override.tf
+_override.tf.json
+.terraformrc
+terraform.rc
+tfplan
+infra/dcp/backend.tf
+
+# Configuration
+infra/dcp/.env
+
+*.pyc
+.venv/
+uv.lock

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ infra/dcp/.env
 
 *.pyc
 .venv/
-uv.lock

--- a/infra/dcp/README.md
+++ b/infra/dcp/README.md
@@ -1,0 +1,64 @@
+# Data Commons Platform (DCP) Infrastructure
+
+This directory contains the Terraform configuration to deploy the Data Commons Platform on Google Cloud Platform (GCP).
+
+## Prerequisites
+*   **GCP Project**: A GCP project with billing enabled.
+*   **Terraform**: Terraform installed locally (>= 1.0.0).
+*   **gcloud CLI**: GCP CLI installed and authenticated.
+
+## Setup
+
+1.  **Configure Local Variables**:
+    Copy the example variable file and fill in your project details.
+    ```bash
+    cp terraform.tfvars.example terraform.tfvars
+    ```
+    Edit `terraform.tfvars` with your `project_id` and other preferred settings.
+
+2.  **Run Setup Script**:
+    The `setup.sh` script creates a GCS bucket for your Terraform state and initializes the backend.
+    ```bash
+    ./setup.sh
+    ```
+
+## Deployment
+
+1.  **Initialize**:
+    Initialize Terraform (if not already done by setup.sh).
+    ```bash
+    terraform init
+    ```
+
+2.  **Plan**:
+    Review the changes Terraform will make.
+    ```bash
+    terraform plan
+    ```
+
+3.  **Apply**:
+    Provision the infrastructure.
+    ```bash
+    terraform apply
+    ```
+
+4.  **Teardown**:
+    Destroy all resources.
+    ```bash
+    terraform destroy
+    ```
+
+## Architecture
+
+This setup uses an **Orchestrator Pattern**:
+- `infra/dcp/main.tf`: The root entrypoint that calls modules.
+- `infra/dcp/modules/dcp/`: The new Data Commons Platform stack (Cloud Run + Spanner).
+- `infra/dcp/modules/cdc/`: The legacy Custom Data Commons stack (Cloud Run + MySQL + Redis).
+
+Each module is independent and can be toggled via the root variables in `terraform.tfvars`.
+
+## Troubleshooting
+*   **Deletion Errors**: If you get a "cannot destroy... deletion_protection" error, ensure `deletion_protection = false` in your `terraform.tfvars`, run `terraform apply`, and then try `terraform destroy` again. Alternatively, use the helper command:
+    ```bash
+    make force-destroy
+    ```

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -1,0 +1,111 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Enable required APIs for both stacks
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "run.googleapis.com",
+    "spanner.googleapis.com",
+    "iam.googleapis.com",
+    "sqladmin.googleapis.com",
+    "redis.googleapis.com",
+    "secretmanager.googleapis.com",
+    "vpcaccess.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "compute.googleapis.com"
+  ])
+
+  service            = each.key
+  disable_on_destroy = false
+}
+
+# --- Data Commons Platform (DCP) Stack ---
+module "dcp" {
+  source = "./modules/dcp"
+  count  = var.enable_dcp ? 1 : 0
+
+  project_id               = var.project_id
+  region                   = var.region
+  image_url                = var.dcp_image_url
+  service_name             = var.dcp_service_name
+  service_account_name     = var.dcp_service_account_name
+  create_spanner           = var.dcp_create_spanner
+  spanner_instance_id      = var.dcp_spanner_instance_id
+  spanner_database_id      = var.dcp_spanner_database_id
+  spanner_processing_units = var.dcp_spanner_processing_units
+  cpu                      = var.dcp_cpu
+  memory                   = var.dcp_memory
+  min_instances            = var.dcp_min_instances
+  max_instances            = var.dcp_max_instances
+  concurrency              = var.dcp_concurrency
+  timeout_seconds          = var.dcp_timeout_seconds
+  deletion_protection      = var.deletion_protection
+
+  depends_on = [google_project_service.apis]
+}
+
+# --- Custom Data Commons (CDC) Legacy Stack ---
+module "cdc" {
+  source = "./modules/cdc"
+  count  = var.enable_cdc ? 1 : 0
+
+  project_id                    = var.project_id
+  namespace                     = var.cdc_namespace
+  dc_api_key                    = var.cdc_dc_api_key
+  maps_api_key                  = var.cdc_maps_api_key
+  disable_google_maps           = var.cdc_disable_google_maps
+  region                        = var.region
+  google_analytics_tag_id       = var.cdc_google_analytics_tag_id
+  gcs_data_bucket_name          = var.cdc_gcs_data_bucket_name
+  gcs_data_bucket_input_folder  = var.cdc_gcs_data_bucket_input_folder
+  gcs_data_bucket_output_folder = var.cdc_gcs_data_bucket_output_folder
+  gcs_data_bucket_location      = var.cdc_gcs_data_bucket_location
+  mysql_instance_name           = var.cdc_mysql_instance_name
+  mysql_database_name           = var.cdc_mysql_database_name
+  mysql_database_version        = var.cdc_mysql_database_version
+  mysql_cpu_count               = var.cdc_mysql_cpu_count
+  mysql_memory_size_mb          = var.cdc_mysql_memory_size_mb
+  mysql_storage_size_gb         = var.cdc_mysql_storage_size_gb
+  mysql_user                    = var.cdc_mysql_user
+  mysql_deletion_protection     = var.deletion_protection
+  dc_web_service_image          = var.cdc_web_service_image
+  dc_web_service_min_instance_count = var.cdc_web_service_min_instance_count
+  dc_web_service_max_instance_count = var.cdc_web_service_max_instance_count
+  dc_web_service_cpu            = var.cdc_web_service_cpu
+  dc_web_service_memory         = var.cdc_web_service_memory
+  make_dc_web_service_public    = var.cdc_make_dc_web_service_public
+  dc_data_job_image             = var.cdc_data_job_image
+  dc_data_job_cpu               = var.cdc_data_job_cpu
+  dc_data_job_memory            = var.cdc_data_job_memory
+  dc_data_job_timeout           = var.cdc_data_job_timeout
+  dc_search_scope               = var.cdc_search_scope
+  enable_mcp                   = var.cdc_enable_mcp
+  vpc_network_name              = var.cdc_vpc_network_name
+  vpc_network_subnet_name       = var.cdc_vpc_network_subnet_name
+  enable_redis                  = var.cdc_enable_redis
+  redis_instance_name           = var.cdc_redis_instance_name
+  redis_memory_size_gb          = var.cdc_redis_memory_size_gb
+  redis_tier                    = var.cdc_redis_tier
+  redis_location_id             = var.cdc_redis_location_id
+  redis_alternative_location_id = var.cdc_redis_alternative_location_id
+  redis_replica_count           = var.cdc_redis_replica_count
+  vpc_connector_cidr            = var.cdc_vpc_connector_cidr
+  deletion_protection           = var.deletion_protection
+
+  depends_on = [google_project_service.apis]
+}

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -12,13 +12,16 @@ terraform {
 }
 
 provider "google" {
-  project = var.project_id
-  region  = var.region
+  project               = var.project_id
+  region                = var.region
+  user_project_override = var.user_project_override
+  billing_project       = var.billing_project_id != null ? var.billing_project_id : var.project_id
 }
 
 # Enable required APIs for both stacks
 resource "google_project_service" "apis" {
   for_each = toset(concat([
+    "apikeys.googleapis.com",
     "run.googleapis.com",
     "iam.googleapis.com",
     "sqladmin.googleapis.com",
@@ -31,6 +34,16 @@ resource "google_project_service" "apis" {
 
   service            = each.key
   disable_on_destroy = false
+}
+
+# --- Network Data Sources ---
+data "google_compute_network" "default" {
+  name = var.cdc_vpc_network_name
+}
+
+data "google_compute_subnetwork" "default" {
+  name   = var.cdc_vpc_network_subnet_name
+  region = var.region
 }
 
 # --- Data Commons Platform (DCP) Stack ---
@@ -106,6 +119,7 @@ module "cdc" {
   redis_alternative_location_id = var.cdc_redis_alternative_location_id
   redis_replica_count           = var.cdc_redis_replica_count
   vpc_connector_cidr            = var.cdc_vpc_connector_cidr
+  vpc_network_id                = data.google_compute_network.default.id
   use_spanner                   = var.enable_dcp
   spanner_instance_id           = var.enable_dcp ? module.dcp[0].spanner_instance_id : ""
   spanner_database_id           = var.enable_dcp ? module.dcp[0].spanner_database_id : ""

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -18,9 +18,8 @@ provider "google" {
 
 # Enable required APIs for both stacks
 resource "google_project_service" "apis" {
-  for_each = toset([
+  for_each = toset(concat([
     "run.googleapis.com",
-    "spanner.googleapis.com",
     "iam.googleapis.com",
     "sqladmin.googleapis.com",
     "redis.googleapis.com",
@@ -28,7 +27,7 @@ resource "google_project_service" "apis" {
     "vpcaccess.googleapis.com",
     "artifactregistry.googleapis.com",
     "compute.googleapis.com"
-  ])
+  ], var.enable_dcp ? ["spanner.googleapis.com"] : []))
 
   service            = each.key
   disable_on_destroy = false
@@ -118,7 +117,7 @@ module "cdc" {
 # Ensure Spanner instance ID is provided when not creating a new one
 check "spanner_instance_id_provided" {
   assert {
-    condition     = var.dcp_create_spanner_instance || var.dcp_spanner_instance_id != ""
-    error_message = "dcp_spanner_instance_id must be provided when dcp_create_spanner_instance is false."
+    condition     = !var.enable_dcp || var.dcp_create_spanner_instance || var.dcp_spanner_instance_id != ""
+    error_message = "dcp_spanner_instance_id must be provided when reusing an existing instance (dcp_create_spanner_instance = false)."
   }
 }

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -40,20 +40,22 @@ module "dcp" {
   count  = var.enable_dcp ? 1 : 0
 
   project_id               = var.project_id
+  namespace                = var.namespace
   region                   = var.region
   image_url                = var.dcp_image_url
   service_name             = var.dcp_service_name
   service_account_name     = var.dcp_service_account_name
-  create_spanner           = var.dcp_create_spanner
+  create_spanner_instance  = var.dcp_create_spanner_instance
+  create_spanner_db        = var.dcp_create_spanner_db
   spanner_instance_id      = var.dcp_spanner_instance_id
   spanner_database_id      = var.dcp_spanner_database_id
   spanner_processing_units = var.dcp_spanner_processing_units
-  cpu                      = var.dcp_cpu
-  memory                   = var.dcp_memory
-  min_instances            = var.dcp_min_instances
-  max_instances            = var.dcp_max_instances
-  concurrency              = var.dcp_concurrency
-  timeout_seconds          = var.dcp_timeout_seconds
+  service_cpu              = var.dcp_service_cpu
+  service_memory           = var.dcp_service_memory
+  service_min_instances    = var.dcp_service_min_instances
+  service_max_instances    = var.dcp_service_max_instances
+  service_concurrency      = var.dcp_service_concurrency
+  service_timeout_seconds  = var.dcp_service_timeout_seconds
   deletion_protection      = var.deletion_protection
 
   depends_on = [google_project_service.apis]
@@ -65,7 +67,7 @@ module "cdc" {
   count  = var.enable_cdc ? 1 : 0
 
   project_id                    = var.project_id
-  namespace                     = var.cdc_namespace
+  namespace                     = var.namespace
   dc_api_key                    = var.cdc_dc_api_key
   maps_api_key                  = var.cdc_maps_api_key
   disable_google_maps           = var.cdc_disable_google_maps
@@ -105,7 +107,18 @@ module "cdc" {
   redis_alternative_location_id = var.cdc_redis_alternative_location_id
   redis_replica_count           = var.cdc_redis_replica_count
   vpc_connector_cidr            = var.cdc_vpc_connector_cidr
+  use_spanner                   = var.enable_dcp
+  spanner_instance_id           = var.enable_dcp ? module.dcp[0].spanner_instance_id : ""
+  spanner_database_id           = var.enable_dcp ? module.dcp[0].spanner_database_id : ""
   deletion_protection           = var.deletion_protection
 
   depends_on = [google_project_service.apis]
+}
+
+# Ensure Spanner instance ID is provided when not creating a new one
+check "spanner_instance_id_provided" {
+  assert {
+    condition     = var.dcp_create_spanner_instance || var.dcp_spanner_instance_id != ""
+    error_message = "dcp_spanner_instance_id must be provided when dcp_create_spanner_instance is false."
+  }
 }

--- a/infra/dcp/modules/cdc/locals.tf
+++ b/infra/dcp/modules/cdc/locals.tf
@@ -85,6 +85,15 @@ locals {
           version = "latest"
         }
       }
+    },
+    {
+      name = "MAPS_API_KEY"
+      value_source = {
+        secret_key_ref = {
+          secret  = var.disable_google_maps ? "" : google_secret_manager_secret.maps_api_key[0].secret_id
+          version = "latest"
+        }
+      }
     }
   ], var.use_spanner ? [] : [
     {

--- a/infra/dcp/modules/cdc/locals.tf
+++ b/infra/dcp/modules/cdc/locals.tf
@@ -1,0 +1,90 @@
+# Local variable definitions
+
+locals {
+  # Data Commons Data Bucket
+  gcs_data_bucket_name = var.gcs_data_bucket_name != "" ? var.gcs_data_bucket_name : "${var.namespace}-datacommons-data-${var.project_id}"
+
+  # Use var.maps_api_key if set, otherwise use generated Maps API key
+  maps_api_key = var.maps_api_key != null ? var.maps_api_key : google_apikeys_key.maps_api_key[0].key_string
+
+  # Data Commons API hostname
+  dc_api_hostname = "api.datacommons.org"
+
+  # Data Commons API protocol
+  dc_api_protocol = "https"
+
+  # Data Commons API root URL
+  dc_api_root = "${local.dc_api_protocol}://${local.dc_api_hostname}"
+
+  # Optionally-configured Redis instance
+  redis_instance = var.enable_redis ? google_redis_instance.redis_instance[0] : null
+
+
+  # Shared environment variables used by the Data Commons web service and the Data
+  # Commons data loading job
+  cloud_run_shared_env_variables = [
+    {
+      name  = "USE_CLOUDSQL"
+      value = "true"
+    },
+    {
+      name  = "CLOUDSQL_INSTANCE"
+      value = google_sql_database_instance.mysql_instance.connection_name
+    },
+    {
+      name  = "DB_NAME"
+      value = var.mysql_database_name
+    },
+    {
+      name  = "DB_USER"
+      value = var.mysql_user
+    },
+    {
+      name  = "DB_HOST"
+      value = ""
+    },
+    {
+      name  = "DB_PORT"
+      value = "3306"
+    },
+    {
+      name  = "OUTPUT_DIR"
+      value = "gs://${local.gcs_data_bucket_name}/${var.gcs_data_bucket_output_folder}"
+    },
+    {
+      name  = "FORCE_RESTART"
+      value = "${timestamp()}"
+    },
+    {
+      name  = "REDIS_HOST"
+      value = try(local.redis_instance.host, "")
+    },
+    {
+      name  = "REDIS_PORT"
+      value = try(local.redis_instance.port, "")
+    }
+  ]
+
+  # Shared environment variables containing secret refs used by the Data Commons
+  # web service and the Data Commons data loading job
+  cloud_run_shared_env_variable_secrets = [
+    {
+      name = "DC_API_KEY"
+      value_source = {
+        secret_key_ref = {
+          secret  = google_secret_manager_secret.dc_api_key.secret_id
+          version = "latest"
+        }
+      }
+    },
+    {
+      name = "DB_PASS"
+      value_source = {
+        secret_key_ref = {
+          secret  = google_secret_manager_secret.mysql_password_secret.secret_id
+          version = "latest"
+        }
+      }
+    }
+  ]
+}

--- a/infra/dcp/modules/cdc/locals.tf
+++ b/infra/dcp/modules/cdc/locals.tf
@@ -2,7 +2,8 @@
 
 locals {
   # Data Commons Data Bucket
-  gcs_data_bucket_name = var.gcs_data_bucket_name != "" ? var.gcs_data_bucket_name : "${var.namespace}-datacommons-data-${var.project_id}"
+  name_prefix = var.namespace != "" ? "${var.namespace}-" : ""
+  gcs_data_bucket_name = var.gcs_data_bucket_name != "" ? var.gcs_data_bucket_name : "${local.name_prefix}datacommons-data-${var.project_id}"
 
   # Use var.maps_api_key if set, otherwise use generated Maps API key
   maps_api_key = var.maps_api_key != null ? var.maps_api_key : google_apikeys_key.maps_api_key[0].key_string
@@ -25,11 +26,11 @@ locals {
   cloud_run_shared_env_variables = [
     {
       name  = "USE_CLOUDSQL"
-      value = "true"
+      value = var.use_spanner ? "false" : "true"
     },
     {
       name  = "CLOUDSQL_INSTANCE"
-      value = google_sql_database_instance.mysql_instance.connection_name
+      value = var.use_spanner ? "" : google_sql_database_instance.mysql_instance[0].connection_name
     },
     {
       name  = "DB_NAME"
@@ -62,12 +63,20 @@ locals {
     {
       name  = "REDIS_PORT"
       value = try(local.redis_instance.port, "")
+    },
+    {
+      name  = "GCP_SPANNER_INSTANCE_ID"
+      value = var.spanner_instance_id
+    },
+    {
+      name  = "GCP_SPANNER_DATABASE_NAME"
+      value = var.spanner_database_id
     }
   ]
 
   # Shared environment variables containing secret refs used by the Data Commons
   # web service and the Data Commons data loading job
-  cloud_run_shared_env_variable_secrets = [
+  cloud_run_shared_env_variable_secrets = concat([
     {
       name = "DC_API_KEY"
       value_source = {
@@ -76,15 +85,16 @@ locals {
           version = "latest"
         }
       }
-    },
+    }
+  ], var.use_spanner ? [] : [
     {
       name = "DB_PASS"
       value_source = {
         secret_key_ref = {
-          secret  = google_secret_manager_secret.mysql_password_secret.secret_id
+          secret  = google_secret_manager_secret.mysql_password_secret[0].id
           version = "latest"
         }
       }
     }
-  ]
+  ])
 }

--- a/infra/dcp/modules/cdc/main.tf
+++ b/infra/dcp/modules/cdc/main.tf
@@ -44,7 +44,8 @@ resource "google_project_service" "required_apis" {
 
 # Cloud SQL instance for Data Commons
 resource "google_sql_database_instance" "mysql_instance" {
-  name             = "${var.namespace}-${var.mysql_instance_name}"
+  count            = var.use_spanner ? 0 : 1
+  name             = "${local.name_prefix}${var.mysql_instance_name}"
   database_version = var.mysql_database_version
   region           = var.region
 
@@ -64,8 +65,9 @@ resource "google_sql_database_instance" "mysql_instance" {
 
 # MySQL Database
 resource "google_sql_database" "mysql_db" {
+  count    = var.use_spanner ? 0 : 1
   name     = var.mysql_database_name
-  instance = google_sql_database_instance.mysql_instance.name
+  instance = google_sql_database_instance.mysql_instance[0].name
 }
 
 # Generate a random password for the MySQL user
@@ -76,7 +78,8 @@ resource "random_password" "mysql_password" {
 
 # Store MySQL password in Secret Manager
 resource "google_secret_manager_secret" "mysql_password_secret" {
-  secret_id = "${var.namespace}-mysql-password"
+  count     = var.use_spanner ? 0 : 1
+  secret_id = "${local.name_prefix}mysql-password"
 
   replication {
     auto {}
@@ -85,21 +88,23 @@ resource "google_secret_manager_secret" "mysql_password_secret" {
 }
 
 resource "google_secret_manager_secret_version" "mysql_password_secret_version" {
-  secret      = google_secret_manager_secret.mysql_password_secret.id
+  count       = var.use_spanner ? 0 : 1
+  secret      = google_secret_manager_secret.mysql_password_secret[0].id
   secret_data = random_password.mysql_password.result
 }
 
 # MySQL User
 resource "google_sql_user" "mysql_user" {
+  count    = var.use_spanner ? 0 : 1
   name     = var.mysql_user
-  instance = google_sql_database_instance.mysql_instance.name
+  instance = google_sql_database_instance.mysql_instance[0].name
   password = random_password.mysql_password.result
 }
 
 # Optional Redis instance
 resource "google_redis_instance" "redis_instance" {
   count              = var.enable_redis ? 1 : 0
-  name               = "${var.namespace}-${var.redis_instance_name}"
+  name               = "${local.name_prefix}${var.redis_instance_name}"
   memory_size_gb     = var.redis_memory_size_gb
   tier               = var.redis_tier
   region             = var.region
@@ -116,7 +121,7 @@ resource "google_redis_instance" "redis_instance" {
 
 # VPC Access Connector for private connections
 resource "google_vpc_access_connector" "connector" {
-  name          = "${var.namespace}-vpc-conn-v2"
+  name          = "${local.name_prefix}vpc-conn"
   region        = var.region
   network       = data.google_compute_network.default.name
   ip_cidr_range = var.vpc_connector_cidr
@@ -138,8 +143,8 @@ resource "google_storage_bucket" "data_bucket" {
 # Maps API Key
 resource "google_apikeys_key" "maps_api_key" {
   count        = var.maps_api_key == null && !var.disable_google_maps ? 1 : 0
-  name         = "${var.namespace}-maps-key"
-  display_name = "Maps API Key for ${var.namespace}"
+  name         = "${local.name_prefix}maps-key"
+  display_name = "Maps API Key for ${var.namespace != "" ? var.namespace : "Data Commons"}"
   project      = var.project_id
 
   restrictions {
@@ -152,7 +157,7 @@ resource "google_apikeys_key" "maps_api_key" {
 
 # Cloud Run job for data management
 resource "google_cloud_run_v2_job" "dc_data_job" {
-  name                = "${var.namespace}-datacommons-data-job"
+  name                = "${local.name_prefix}datacommons-data-job"
   location            = var.region
   deletion_protection = var.deletion_protection
 
@@ -219,8 +224,7 @@ resource "google_cloud_run_v2_job" "dc_data_job" {
 # Run the db init job on terraform apply to create tables
 resource "null_resource" "run_db_init" {
   depends_on = [
-    google_cloud_run_v2_job.dc_data_job,
-    google_sql_database_instance.mysql_instance
+    google_cloud_run_v2_job.dc_data_job
   ]
 
   triggers = {
@@ -230,7 +234,7 @@ resource "null_resource" "run_db_init" {
 
   provisioner "local-exec" {
     command = <<EOT
-      gcloud run jobs execute ${google_cloud_run_v2_job.dc_data_job.name} \
+      gcloud run jobs execute ${local.name_prefix}datacommons-data-job \
         --update-env-vars DATA_RUN_MODE=schemaupdate \
         --region=${var.region} \
         --project=${var.project_id} \
@@ -241,7 +245,7 @@ EOT
 
 # Cloud Run service for Data Commons website
 resource "google_cloud_run_v2_service" "dc_web_service" {
-  name                = "${var.namespace}-datacommons-web-service"
+  name                = "${local.name_prefix}datacommons-web-service"
   location            = var.region
   deletion_protection = var.deletion_protection
 
@@ -315,10 +319,13 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
       max_instance_count = var.dc_web_service_max_instance_count
     }
     service_account = google_service_account.datacommons_service_account.email
-    volumes {
-      name = "cloudsql"
-      cloud_sql_instance {
-        instances = [google_sql_database_instance.mysql_instance.connection_name]
+    dynamic "volumes" {
+      for_each = var.use_spanner ? [] : [1]
+      content {
+        name = "cloudsql"
+        cloud_sql_instance {
+          instances = [google_sql_database_instance.mysql_instance[0].connection_name]
+        }
       }
     }
   }

--- a/infra/dcp/modules/cdc/main.tf
+++ b/infra/dcp/modules/cdc/main.tf
@@ -294,10 +294,6 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
       }
 
       env {
-        name  = "MAPS_API_KEY"
-        value = local.maps_api_key
-      }
-      env {
         name  = "GOOGLE_ANALYTICS_TAG_ID"
         value = var.google_analytics_tag_id != null ? var.google_analytics_tag_id : ""
       }

--- a/infra/dcp/modules/cdc/main.tf
+++ b/infra/dcp/modules/cdc/main.tf
@@ -1,0 +1,339 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Custom Data Commons terraform resources
+
+# Reference the default VPC network
+data "google_compute_network" "default" {
+  name = var.vpc_network_name
+}
+
+# Reference the default VPC network subnet
+data "google_compute_subnetwork" "default" {
+  name   = var.vpc_network_subnet_name
+  region = var.region
+}
+
+# Enable required Google Cloud APIs
+resource "google_project_service" "required_apis" {
+  for_each = toset([
+    "run.googleapis.com",
+    "sqladmin.googleapis.com",
+    "compute.googleapis.com",
+    "redis.googleapis.com",
+    "secretmanager.googleapis.com",
+    "vpcaccess.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "iam.googleapis.com"
+  ])
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# Cloud SQL instance for Data Commons
+resource "google_sql_database_instance" "mysql_instance" {
+  name             = "${var.namespace}-${var.mysql_instance_name}"
+  database_version = var.mysql_database_version
+  region           = var.region
+
+  settings {
+    tier = "db-custom-${var.mysql_cpu_count}-${var.mysql_memory_size_mb}"
+    ip_configuration {
+      ipv4_enabled = true
+    }
+    backup_configuration {
+      enabled = true
+    }
+  }
+
+  deletion_protection = var.deletion_protection
+  depends_on          = [google_project_service.required_apis]
+}
+
+# MySQL Database
+resource "google_sql_database" "mysql_db" {
+  name     = var.mysql_database_name
+  instance = google_sql_database_instance.mysql_instance.name
+}
+
+# Generate a random password for the MySQL user
+resource "random_password" "mysql_password" {
+  length  = 16
+  special = true
+}
+
+# Store MySQL password in Secret Manager
+resource "google_secret_manager_secret" "mysql_password_secret" {
+  secret_id = "${var.namespace}-mysql-password"
+
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.required_apis]
+}
+
+resource "google_secret_manager_secret_version" "mysql_password_secret_version" {
+  secret      = google_secret_manager_secret.mysql_password_secret.id
+  secret_data = random_password.mysql_password.result
+}
+
+# MySQL User
+resource "google_sql_user" "mysql_user" {
+  name     = var.mysql_user
+  instance = google_sql_database_instance.mysql_instance.name
+  password = random_password.mysql_password.result
+}
+
+# Optional Redis instance
+resource "google_redis_instance" "redis_instance" {
+  count              = var.enable_redis ? 1 : 0
+  name               = "${var.namespace}-${var.redis_instance_name}"
+  memory_size_gb     = var.redis_memory_size_gb
+  tier               = var.redis_tier
+  region             = var.region
+  location_id        = var.redis_location_id
+  alternative_location_id = var.redis_alternative_location_id
+  redis_version      = "REDIS_6_X"
+  display_name       = "Data Commons Redis Instance"
+  reserved_ip_range  = null
+  replica_count      = var.redis_replica_count
+  authorized_network = data.google_compute_network.default.id
+  connect_mode       = "DIRECT_PEERING"
+  depends_on         = [google_project_service.required_apis]
+}
+
+# VPC Access Connector for private connections
+resource "google_vpc_access_connector" "connector" {
+  name          = "${var.namespace}-vpc-conn-v2"
+  region        = var.region
+  network       = data.google_compute_network.default.name
+  ip_cidr_range = var.vpc_connector_cidr
+  min_instances = 2
+  max_instances = 10
+  depends_on    = [google_project_service.required_apis]
+}
+
+# GCS Bucket for data storage
+resource "google_storage_bucket" "data_bucket" {
+  name          = local.gcs_data_bucket_name
+  location      = var.gcs_data_bucket_location
+  force_destroy = true
+
+  uniform_bucket_level_access = true
+  depends_on                  = [google_project_service.required_apis]
+}
+
+# Maps API Key
+resource "google_apikeys_key" "maps_api_key" {
+  count        = var.maps_api_key == null && !var.disable_google_maps ? 1 : 0
+  name         = "${var.namespace}-maps-key"
+  display_name = "Maps API Key for ${var.namespace}"
+  project      = var.project_id
+
+  restrictions {
+    api_targets {
+      service = "maps-backend.googleapis.com"
+    }
+  }
+  depends_on = [google_project_service.required_apis]
+}
+
+# Cloud Run job for data management
+resource "google_cloud_run_v2_job" "dc_data_job" {
+  name                = "${var.namespace}-datacommons-data-job"
+  location            = var.region
+  deletion_protection = var.deletion_protection
+
+  template {
+    template {
+      containers {
+        image = var.dc_data_job_image
+        resources {
+          limits = {
+            cpu    = var.dc_data_job_cpu
+            memory = var.dc_data_job_memory
+          }
+        }
+        dynamic "env" {
+          for_each = local.cloud_run_shared_env_variables
+          content {
+            name  = env.value.name
+            value = env.value.value
+          }
+        }
+
+        dynamic "env" {
+          for_each = local.cloud_run_shared_env_variable_secrets
+          content {
+            name = env.value.name
+            value_source {
+              secret_key_ref {
+                secret  = env.value.value_source.secret_key_ref.secret
+                version = env.value.value_source.secret_key_ref.version
+              }
+            }
+          }
+        }
+
+        env {
+          name  = "GCS_BUCKET"
+          value = google_storage_bucket.data_bucket.name
+        }
+        env {
+          name  = "GCS_INPUT_FOLDER"
+          value = var.gcs_data_bucket_input_folder
+        }
+        env {
+          name  = "GCS_OUTPUT_FOLDER"
+          value = var.gcs_data_bucket_output_folder
+        }
+        env {
+          name  = "INPUT_DIR"
+          value = "gs://${google_storage_bucket.data_bucket.name}/${var.gcs_data_bucket_input_folder}"
+        }
+      }
+      vpc_access {
+        connector = google_vpc_access_connector.connector.id
+        egress    = "PRIVATE_RANGES_ONLY"
+      }
+      max_retries = 0
+      timeout     = var.dc_data_job_timeout
+      service_account = google_service_account.datacommons_service_account.email
+    }
+  }
+  depends_on = [google_project_service.required_apis]
+}
+
+# Run the db init job on terraform apply to create tables
+resource "null_resource" "run_db_init" {
+  depends_on = [
+    google_cloud_run_v2_job.dc_data_job,
+    google_sql_database_instance.mysql_instance
+  ]
+
+  triggers = {
+    # Run once per deployment or when the job image changes
+    job_image = var.dc_data_job_image
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      gcloud run jobs execute ${google_cloud_run_v2_job.dc_data_job.name} \
+        --update-env-vars DATA_RUN_MODE=schemaupdate \
+        --region=${var.region} \
+        --project=${var.project_id} \
+        --wait
+EOT
+  }
+}
+
+# Cloud Run service for Data Commons website
+resource "google_cloud_run_v2_service" "dc_web_service" {
+  name                = "${var.namespace}-datacommons-web-service"
+  location            = var.region
+  deletion_protection = var.deletion_protection
+
+  template {
+    timeout = "300s"
+    containers {
+      image = var.dc_web_service_image
+      resources {
+        limits = {
+          cpu    = var.dc_web_service_cpu
+          memory = var.dc_web_service_memory
+        }
+      }
+      ports {
+        container_port = 8080
+      }
+
+      startup_probe {
+        timeout_seconds   = 120
+        period_seconds    = 30
+        failure_threshold = 6
+        tcp_socket {
+          port = 8080
+        }
+      }
+
+      dynamic "env" {
+        for_each = local.cloud_run_shared_env_variables
+        content {
+          name  = env.value.name
+          value = env.value.value
+        }
+      }
+
+      dynamic "env" {
+        for_each = local.cloud_run_shared_env_variable_secrets
+        content {
+          name = env.value.name
+          value_source {
+            secret_key_ref {
+              secret  = env.value.value_source.secret_key_ref.secret
+              version = env.value.value_source.secret_key_ref.version
+            }
+          }
+        }
+      }
+
+      env {
+        name  = "MAPS_API_KEY"
+        value = local.maps_api_key
+      }
+      env {
+        name  = "GOOGLE_ANALYTICS_TAG_ID"
+        value = var.google_analytics_tag_id != null ? var.google_analytics_tag_id : ""
+      }
+      env {
+        name  = "DC_SEARCH_SCOPE"
+        value = var.dc_search_scope
+      }
+      env {
+        name  = "ENABLE_MCP"
+        value = var.enable_mcp ? "true" : "false"
+      }
+    }
+    vpc_access {
+      connector = google_vpc_access_connector.connector.id
+      egress    = "PRIVATE_RANGES_ONLY"
+    }
+    scaling {
+      min_instance_count = var.dc_web_service_min_instance_count
+      max_instance_count = var.dc_web_service_max_instance_count
+    }
+    service_account = google_service_account.datacommons_service_account.email
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [google_sql_database_instance.mysql_instance.connection_name]
+      }
+    }
+  }
+  depends_on = [
+    google_project_service.required_apis,
+    null_resource.run_db_init
+  ]
+}
+
+# Make the service public if requested
+resource "google_cloud_run_service_iam_member" "public_access" {
+  count    = var.make_dc_web_service_public ? 1 : 0
+  location = google_cloud_run_v2_service.dc_web_service.location
+  project  = google_cloud_run_v2_service.dc_web_service.project
+  service  = google_cloud_run_v2_service.dc_web_service.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/infra/dcp/modules/cdc/main.tf
+++ b/infra/dcp/modules/cdc/main.tf
@@ -14,34 +14,6 @@
 
 # Custom Data Commons terraform resources
 
-# Reference the default VPC network
-data "google_compute_network" "default" {
-  name = var.vpc_network_name
-}
-
-# Reference the default VPC network subnet
-data "google_compute_subnetwork" "default" {
-  name   = var.vpc_network_subnet_name
-  region = var.region
-}
-
-# Enable required Google Cloud APIs
-resource "google_project_service" "required_apis" {
-  for_each = toset([
-    "run.googleapis.com",
-    "sqladmin.googleapis.com",
-    "compute.googleapis.com",
-    "redis.googleapis.com",
-    "secretmanager.googleapis.com",
-    "vpcaccess.googleapis.com",
-    "artifactregistry.googleapis.com",
-    "iam.googleapis.com"
-  ])
-  project            = var.project_id
-  service            = each.value
-  disable_on_destroy = false
-}
-
 # Cloud SQL instance for Data Commons
 resource "google_sql_database_instance" "mysql_instance" {
   count            = var.use_spanner ? 0 : 1
@@ -60,7 +32,6 @@ resource "google_sql_database_instance" "mysql_instance" {
   }
 
   deletion_protection = var.deletion_protection
-  depends_on          = [google_project_service.required_apis]
 }
 
 # MySQL Database
@@ -84,7 +55,6 @@ resource "google_secret_manager_secret" "mysql_password_secret" {
   replication {
     auto {}
   }
-  depends_on = [google_project_service.required_apis]
 }
 
 resource "google_secret_manager_secret_version" "mysql_password_secret_version" {
@@ -114,20 +84,18 @@ resource "google_redis_instance" "redis_instance" {
   display_name       = "Data Commons Redis Instance"
   reserved_ip_range  = null
   replica_count      = var.redis_replica_count
-  authorized_network = data.google_compute_network.default.id
+  authorized_network = var.vpc_network_id
   connect_mode       = "DIRECT_PEERING"
-  depends_on         = [google_project_service.required_apis]
 }
 
 # VPC Access Connector for private connections
 resource "google_vpc_access_connector" "connector" {
   name          = "${local.name_prefix}vpc-conn"
   region        = var.region
-  network       = data.google_compute_network.default.name
+  network       = var.vpc_network_name
   ip_cidr_range = var.vpc_connector_cidr
   min_instances = 2
   max_instances = 10
-  depends_on    = [google_project_service.required_apis]
 }
 
 # GCS Bucket for data storage
@@ -137,7 +105,6 @@ resource "google_storage_bucket" "data_bucket" {
   force_destroy = true
 
   uniform_bucket_level_access = true
-  depends_on                  = [google_project_service.required_apis]
 }
 
 # Maps API Key
@@ -152,7 +119,6 @@ resource "google_apikeys_key" "maps_api_key" {
       service = "maps-backend.googleapis.com"
     }
   }
-  depends_on = [google_project_service.required_apis]
 }
 
 # Cloud Run job for data management
@@ -218,11 +184,18 @@ resource "google_cloud_run_v2_job" "dc_data_job" {
       service_account = google_service_account.datacommons_service_account.email
     }
   }
-  depends_on = [google_project_service.required_apis]
+
+  depends_on = [
+    google_secret_manager_secret_version.mysql_password_secret_version,
+    google_secret_manager_secret_version.dc_api_key_version,
+    google_secret_manager_secret_version.maps_api_key_version
+  ]
 }
 
 # Run the db init job on terraform apply to create tables
 resource "null_resource" "run_db_init" {
+  count = var.use_spanner ? 0 : 1
+
   depends_on = [
     google_cloud_run_v2_job.dc_data_job
   ]
@@ -326,7 +299,6 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
     }
   }
   depends_on = [
-    google_project_service.required_apis,
     null_resource.run_db_init
   ]
 }

--- a/infra/dcp/modules/cdc/main.tf
+++ b/infra/dcp/modules/cdc/main.tf
@@ -118,6 +118,9 @@ resource "google_apikeys_key" "maps_api_key" {
     api_targets {
       service = "maps-backend.googleapis.com"
     }
+    api_targets {
+      service = "places_backend"
+    }
   }
 }
 

--- a/infra/dcp/modules/cdc/outputs.tf
+++ b/infra/dcp/modules/cdc/outputs.tf
@@ -10,12 +10,12 @@ output "redis_instance_port" {
 
 output "mysql_instance_connection_name" {
   description = "The connection name of the MySQL instance"
-  value       = google_sql_database_instance.mysql_instance.connection_name
+  value       = var.use_spanner ? null : google_sql_database_instance.mysql_instance[0].connection_name
 }
 
 output "mysql_instance_public_ip" {
   description = "The public IP address of the MySQL instance"
-  value       = google_sql_database_instance.mysql_instance.public_ip_address
+  value       = var.use_spanner ? null : google_sql_database_instance.mysql_instance[0].public_ip_address
 }
 
 output "mysql_user" {

--- a/infra/dcp/modules/cdc/outputs.tf
+++ b/infra/dcp/modules/cdc/outputs.tf
@@ -1,0 +1,45 @@
+output "redis_instance_host" {
+  description = "The hostname or IP address of the Redis instance"
+  value       = try(local.redis_instance.host, "")
+}
+
+output "redis_instance_port" {
+  description = "The port number the Redis instance is listening on"
+  value       = try(local.redis_instance.port, "")
+}
+
+output "mysql_instance_connection_name" {
+  description = "The connection name of the MySQL instance"
+  value       = google_sql_database_instance.mysql_instance.connection_name
+}
+
+output "mysql_instance_public_ip" {
+  description = "The public IP address of the MySQL instance"
+  value       = google_sql_database_instance.mysql_instance.public_ip_address
+}
+
+output "mysql_user" {
+  description = "MySQL user name"
+  value       = var.mysql_user
+  sensitive   = true
+}
+
+output "mysql_user_password" {
+  description = "The password for the MySQL user"
+  value       = random_password.mysql_password.result
+  sensitive   = true
+}
+
+output "gcs_data_bucket_name" {
+  value = local.gcs_data_bucket_name
+}
+
+output "cloud_run_service_name" {
+  description = "Name of the Data Commons Cloud Run Web service"
+  value       = google_cloud_run_v2_service.dc_web_service.name
+}
+
+output "cloud_run_service_url" {
+  description = "URL of the Data Commons Cloud Run Web service"
+  value       = google_cloud_run_v2_service.dc_web_service.uri
+}

--- a/infra/dcp/modules/cdc/service_account.tf
+++ b/infra/dcp/modules/cdc/service_account.tf
@@ -1,18 +1,18 @@
 # Custom Data Commons service account
 resource "google_service_account" "datacommons_service_account" {
-  account_id   = "${var.namespace}-datacommons-sa"
-  display_name = "Data Commons Service Account for ${var.project_id} (namespace = ${var.namespace})"
+  account_id   = "${local.name_prefix}datacommons-sa"
+  display_name = "Data Commons Service Account for ${var.project_id}${var.namespace != "" ? " (namespace = ${var.namespace})" : ""}"
 }
 
 resource "google_project_iam_member" "datacommons_service_account_roles" {
-  for_each = toset(["roles/compute.networkViewer", "roles/redis.editor", "roles/cloudsql.admin", "roles/storage.objectAdmin", "roles/run.admin", "roles/vpcaccess.user", "roles/iam.serviceAccountUser", "roles/secretmanager.secretAccessor"])
+  for_each = toset(["roles/compute.networkViewer", "roles/redis.editor", "roles/cloudsql.admin", "roles/storage.objectAdmin", "roles/run.admin", "roles/vpcaccess.user", "roles/iam.serviceAccountUser", "roles/secretmanager.secretAccessor", "roles/spanner.databaseUser"])
   project  = var.project_id
   member   = "serviceAccount:${google_service_account.datacommons_service_account.email}"
   role     = each.value
 }
 
 resource "google_secret_manager_secret" "dc_api_key" {
-  secret_id = "${var.namespace}-dc-api-key"
+  secret_id = "${local.name_prefix}dc-api-key"
   replication {
     auto {}
   }

--- a/infra/dcp/modules/cdc/service_account.tf
+++ b/infra/dcp/modules/cdc/service_account.tf
@@ -5,10 +5,20 @@ resource "google_service_account" "datacommons_service_account" {
 }
 
 resource "google_project_iam_member" "datacommons_service_account_roles" {
-  for_each = toset(["roles/compute.networkViewer", "roles/redis.editor", "roles/cloudsql.admin", "roles/storage.objectAdmin", "roles/run.admin", "roles/vpcaccess.user", "roles/iam.serviceAccountUser", "roles/secretmanager.secretAccessor", "roles/spanner.databaseUser"])
-  project  = var.project_id
-  member   = "serviceAccount:${google_service_account.datacommons_service_account.email}"
-  role     = each.value
+  for_each = setsubtract(toset([
+    "roles/compute.networkViewer",
+    "roles/redis.editor",
+    "roles/cloudsql.admin",
+    "roles/storage.objectAdmin",
+    "roles/run.admin",
+    "roles/vpcaccess.user",
+    "roles/iam.serviceAccountUser",
+    "roles/secretmanager.secretAccessor",
+    "roles/spanner.databaseUser"
+  ]), var.use_spanner ? [] : ["roles/spanner.databaseUser"])
+  project = var.project_id
+  member  = "serviceAccount:${google_service_account.datacommons_service_account.email}"
+  role    = each.value
 }
 
 resource "google_secret_manager_secret" "dc_api_key" {

--- a/infra/dcp/modules/cdc/service_account.tf
+++ b/infra/dcp/modules/cdc/service_account.tf
@@ -32,3 +32,17 @@ resource "google_secret_manager_secret_version" "dc_api_key_version" {
   secret      = google_secret_manager_secret.dc_api_key.id
   secret_data = var.dc_api_key
 }
+ 
+resource "google_secret_manager_secret" "maps_api_key" {
+  count     = var.disable_google_maps ? 0 : 1
+  secret_id = "${local.name_prefix}maps-api-key"
+  replication {
+    auto {}
+  }
+}
+ 
+resource "google_secret_manager_secret_version" "maps_api_key_version" {
+  count       = var.disable_google_maps ? 0 : 1
+  secret      = google_secret_manager_secret.maps_api_key[0].id
+  secret_data = local.maps_api_key
+}

--- a/infra/dcp/modules/cdc/service_account.tf
+++ b/infra/dcp/modules/cdc/service_account.tf
@@ -1,0 +1,24 @@
+# Custom Data Commons service account
+resource "google_service_account" "datacommons_service_account" {
+  account_id   = "${var.namespace}-datacommons-sa"
+  display_name = "Data Commons Service Account for ${var.project_id} (namespace = ${var.namespace})"
+}
+
+resource "google_project_iam_member" "datacommons_service_account_roles" {
+  for_each = toset(["roles/compute.networkViewer", "roles/redis.editor", "roles/cloudsql.admin", "roles/storage.objectAdmin", "roles/run.admin", "roles/vpcaccess.user", "roles/iam.serviceAccountUser", "roles/secretmanager.secretAccessor"])
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.datacommons_service_account.email}"
+  role     = each.value
+}
+
+resource "google_secret_manager_secret" "dc_api_key" {
+  secret_id = "${var.namespace}-dc-api-key"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "dc_api_key_version" {
+  secret      = google_secret_manager_secret.dc_api_key.id
+  secret_data = var.dc_api_key
+}

--- a/infra/dcp/modules/cdc/variables.tf
+++ b/infra/dcp/modules/cdc/variables.tf
@@ -187,6 +187,11 @@ variable "vpc_network_name" {
   default     = "default"
 }
 
+variable "vpc_network_id" {
+  description = "VPC network ID"
+  type        = string
+}
+
 variable "vpc_network_subnet_name" {
   description = "VPC network subnet name to use"
   type        = string
@@ -230,7 +235,7 @@ variable "redis_alternative_location_id" {
 }
 
 variable "redis_replica_count" {
-  description = "Redis reserved IP range"
+  description = "Number of Redis replicas"
   type        = number
   default     = 1
 }
@@ -238,7 +243,7 @@ variable "redis_replica_count" {
 variable "vpc_connector_cidr" {
   description = "CIDR range for the VPC Access Connector"
   type        = string
-  default     = "10.8.0.0/28"
+  default     = "10.13.0.0/28"
 }
 
 variable "deletion_protection" {

--- a/infra/dcp/modules/cdc/variables.tf
+++ b/infra/dcp/modules/cdc/variables.tf
@@ -1,0 +1,248 @@
+variable "project_id" {
+  description = "The GCP project ID where the solution will be deployed"
+  type        = string
+}
+
+variable "namespace" {
+  description = "Prefix to apply to resource names for namespacing in a shared GCP account"
+  type        = string
+}
+
+variable "dc_api_key" {
+  description = "Data Commons API Key"
+  type        = string
+}
+
+variable "maps_api_key" {
+  description = "Google Maps API Key"
+  type        = string
+  default     = null
+}
+
+variable "disable_google_maps" {
+  description = "Whether to show Google Maps component on the website"
+  type        = bool
+  default     = false
+}
+
+variable "region" {
+  description = "The GCP region where project resources will be created"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "google_analytics_tag_id" {
+  description = "Google Analytics Tag ID"
+  type        = string
+  default     = null
+}
+
+variable "gcs_data_bucket_name" {
+  description = "Custom GCS data bucket name."
+  type        = string
+  default     = ""
+}
+
+variable "gcs_data_bucket_input_folder" {
+  description = "Input data folder in the GCS data bucket"
+  type        = string
+  default     = "input"
+}
+
+variable "gcs_data_bucket_output_folder" {
+  description = "Output data folder in the GCS data bucket"
+  type        = string
+  default     = "output"
+}
+
+variable "gcs_data_bucket_location" {
+  description = "Data Commons GCS data bucket location"
+  type        = string
+  default     = "US"
+}
+
+variable "mysql_instance_name" {
+  description = "The name of the MySQL instance"
+  type        = string
+  default     = "datacommons-mysql-instance"
+}
+
+variable "mysql_database_name" {
+  description = "MySQL database name"
+  type        = string
+  default     = "datacommons"
+}
+
+variable "mysql_database_version" {
+  description = "The version of MySQL"
+  type        = string
+  default     = "MYSQL_8_0"
+}
+
+variable "mysql_cpu_count" {
+  description = "Number of CPUs for the MySQL instance"
+  type        = number
+  default     = 2
+}
+
+variable "mysql_memory_size_mb" {
+  description = "Memory size for the MySQL instance in MB"
+  type        = number
+  default     = 7680
+}
+
+variable "mysql_storage_size_gb" {
+  description = "SSD storage size for the MySQL instance in GB"
+  type        = number
+  default     = 20
+}
+
+variable "mysql_user" {
+  description = "The username for the MySQL instance"
+  type        = string
+  default     = "datacommons"
+}
+
+variable "mysql_deletion_protection" {
+  description = "Mysql deletion protection"
+  type        = bool
+  default     = false
+}
+
+variable "dc_web_service_image" {
+  description = "Container image for Cloud Run service"
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-services:stable"
+}
+
+variable "dc_web_service_min_instance_count" {
+  description = "Minimum number of instances for the Data Commons service"
+  type        = number
+  default     = 1
+}
+
+variable "dc_web_service_max_instance_count" {
+  description = "Maximum number of instances for the Data Commons service"
+  type        = number
+  default     = 1
+}
+
+variable "dc_web_service_cpu" {
+  description = "CPU limit for the Data Commons service container"
+  type        = string
+  default     = "4"
+}
+
+variable "dc_web_service_memory" {
+  description = "Memory limit for the Data Commons service container"
+  type        = string
+  default     = "16G"
+}
+
+variable "make_dc_web_service_public" {
+  description = "Whether to make the Data Commons Cloud Run service publicly accessible"
+  type        = bool
+  default     = true
+}
+
+variable "dc_data_job_image" {
+  description = "The container image for the data job"
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-data:stable"
+}
+
+variable "dc_data_job_cpu" {
+  description = "CPU limit for the Data Commons data loading job"
+  type        = string
+  default     = "2"
+}
+
+variable "dc_data_job_memory" {
+  description = "Memory limit for the Data Commons data loading job"
+  type        = string
+  default     = "8G"
+}
+
+variable "dc_data_job_timeout" {
+  description = "Timeout for the Data Commons data loading job"
+  type        = string
+  default     = "600s"
+}
+
+variable "dc_search_scope" {
+  description = "Scope for MCP search indicators"
+  type        = string
+  default     = "base_and_custom"
+}
+
+variable "enable_mcp" {
+  description = "Whether to run the MCP server"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_network_name" {
+  description = "VPC network name to use"
+  type        = string
+  default     = "default"
+}
+
+variable "vpc_network_subnet_name" {
+  description = "VPC network subnet name to use"
+  type        = string
+  default     = "default"
+}
+
+variable "enable_redis" {
+  description = "Enable redis instance in this deployment"
+  type        = bool
+  default     = false
+}
+
+variable "redis_instance_name" {
+  description = "Name of the redis instance"
+  type        = string
+  default     = "datacommons-redis-instance"
+}
+
+variable "redis_memory_size_gb" {
+  description = "The memory size for the Redis instance in GB"
+  type        = number
+  default     = 2
+}
+
+variable "redis_tier" {
+  description = "The service tier for the Redis instance"
+  type        = string
+  default     = "STANDARD_HA"
+}
+
+variable "redis_location_id" {
+  description = "Redis location id (zone)"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "redis_alternative_location_id" {
+  description = "Redis alternate location id (alternate zone)"
+  type        = string
+  default     = "us-central1-b"
+}
+
+variable "redis_replica_count" {
+  description = "Redis reserved IP range"
+  type        = number
+  default     = 1
+}
+
+variable "vpc_connector_cidr" {
+  description = "CIDR range for the VPC Access Connector"
+  type        = string
+  default     = "10.8.0.0/28"
+}
+
+variable "deletion_protection" {
+  description = "Enable deletion protection for resources"
+  type        = bool
+  default     = false
+}

--- a/infra/dcp/modules/cdc/variables.tf
+++ b/infra/dcp/modules/cdc/variables.tf
@@ -246,3 +246,21 @@ variable "deletion_protection" {
   type        = bool
   default     = false
 }
+
+variable "use_spanner" {
+  description = "Whether to use Spanner instead of Cloud SQL"
+  type        = bool
+  default     = false
+}
+
+variable "spanner_instance_id" {
+  description = "The Spanner instance ID to use if use_spanner is true"
+  type        = string
+  default     = ""
+}
+
+variable "spanner_database_id" {
+  description = "The Spanner database ID to use if use_spanner is true"
+  type        = string
+  default     = ""
+}

--- a/infra/dcp/modules/dcp/cloudrun.tf
+++ b/infra/dcp/modules/dcp/cloudrun.tf
@@ -1,0 +1,51 @@
+resource "google_cloud_run_v2_service" "dcp_service" {
+  name                = var.service_name
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_ALL"
+  deletion_protection = var.deletion_protection
+
+  template {
+    service_account                  = google_service_account.dcp_runner.email
+    timeout                          = "${var.timeout_seconds}s"
+    max_instance_request_concurrency = var.concurrency
+
+    scaling {
+      min_instance_count = var.min_instances
+      max_instance_count = var.max_instances
+    }
+
+    containers {
+      image = var.image_url
+
+      resources {
+        limits = {
+          cpu    = var.cpu
+          memory = var.memory
+        }
+      }
+
+      ports {
+        container_port = 5000
+      }
+
+      env {
+        name  = "GCP_PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "GCP_SPANNER_INSTANCE_ID"
+        value = var.spanner_instance_id
+      }
+      env {
+        name  = "GCP_SPANNER_DATABASE_NAME"
+        value = var.spanner_database_id
+      }
+    }
+  }
+
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
+}

--- a/infra/dcp/modules/dcp/cloudrun.tf
+++ b/infra/dcp/modules/dcp/cloudrun.tf
@@ -1,17 +1,17 @@
 resource "google_cloud_run_v2_service" "dcp_service" {
-  name                = var.service_name
+  name                = "${local.name_prefix}${var.service_name}"
   location            = var.region
   ingress             = "INGRESS_TRAFFIC_ALL"
   deletion_protection = var.deletion_protection
 
   template {
     service_account                  = google_service_account.dcp_runner.email
-    timeout                          = "${var.timeout_seconds}s"
-    max_instance_request_concurrency = var.concurrency
+    timeout                          = "${var.service_timeout_seconds}s"
+    max_instance_request_concurrency = var.service_concurrency
 
     scaling {
-      min_instance_count = var.min_instances
-      max_instance_count = var.max_instances
+      min_instance_count = var.service_min_instances
+      max_instance_count = var.service_max_instances
     }
 
     containers {
@@ -19,8 +19,8 @@ resource "google_cloud_run_v2_service" "dcp_service" {
 
       resources {
         limits = {
-          cpu    = var.cpu
-          memory = var.memory
+          cpu    = var.service_cpu
+          memory = var.service_memory
         }
       }
 
@@ -34,11 +34,11 @@ resource "google_cloud_run_v2_service" "dcp_service" {
       }
       env {
         name  = "GCP_SPANNER_INSTANCE_ID"
-        value = var.spanner_instance_id
+        value = var.create_spanner_instance ? google_spanner_instance.main[0].name : "${local.name_prefix}${var.spanner_instance_id}"
       }
       env {
         name  = "GCP_SPANNER_DATABASE_NAME"
-        value = var.spanner_database_id
+        value = var.create_spanner_db ? google_spanner_database.database[0].name : "${local.name_prefix}${var.spanner_database_id}"
       }
     }
   }

--- a/infra/dcp/modules/dcp/cloudrun.tf
+++ b/infra/dcp/modules/dcp/cloudrun.tf
@@ -34,11 +34,11 @@ resource "google_cloud_run_v2_service" "dcp_service" {
       }
       env {
         name  = "GCP_SPANNER_INSTANCE_ID"
-        value = var.create_spanner_instance ? google_spanner_instance.main[0].name : "${local.name_prefix}${var.spanner_instance_id}"
+        value = var.create_spanner_instance ? (var.spanner_instance_id != "" ? "${local.name_prefix}${var.spanner_instance_id}" : "${local.name_prefix}dcp-instance") : var.spanner_instance_id
       }
       env {
         name  = "GCP_SPANNER_DATABASE_NAME"
-        value = var.create_spanner_db ? google_spanner_database.database[0].name : "${local.name_prefix}${var.spanner_database_id}"
+        value = var.create_spanner_db ? (var.spanner_database_id != "" ? "${local.name_prefix}${var.spanner_database_id}" : "${local.name_prefix}dcp-db") : var.spanner_database_id
       }
     }
   }

--- a/infra/dcp/modules/dcp/iam.tf
+++ b/infra/dcp/modules/dcp/iam.tf
@@ -1,6 +1,6 @@
 # Service Account for the Cloud Run service
 resource "google_service_account" "dcp_runner" {
-  account_id   = var.service_account_name
+  account_id   = "${local.name_prefix}${var.service_account_name}"
   display_name = "Data Commons Platform Runner"
 }
 

--- a/infra/dcp/modules/dcp/iam.tf
+++ b/infra/dcp/modules/dcp/iam.tf
@@ -1,0 +1,22 @@
+# Service Account for the Cloud Run service
+resource "google_service_account" "dcp_runner" {
+  account_id   = var.service_account_name
+  display_name = "Data Commons Platform Runner"
+}
+
+# Grant Spanner Database User role to the Service Account
+resource "google_project_iam_member" "spanner_user" {
+  project = var.project_id
+  role    = "roles/spanner.databaseUser"
+  member  = "serviceAccount:${google_service_account.dcp_runner.email}"
+}
+
+# Make the Cloud Run service public (optional, can be restricted)
+resource "google_cloud_run_service_iam_binding" "public_invoker" {
+  location = google_cloud_run_v2_service.dcp_service.location
+  service  = google_cloud_run_v2_service.dcp_service.name
+  role     = "roles/run.invoker"
+  members = [
+    "allUsers"
+  ]
+}

--- a/infra/dcp/modules/dcp/locals.tf
+++ b/infra/dcp/modules/dcp/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  name_prefix = var.namespace != "" ? "${var.namespace}-" : ""
+}

--- a/infra/dcp/modules/dcp/outputs.tf
+++ b/infra/dcp/modules/dcp/outputs.tf
@@ -7,9 +7,9 @@ output "service_account_email" {
 }
 
 output "spanner_instance_id" {
-  value = var.create_spanner_instance ? google_spanner_instance.main[0].name : "${local.name_prefix}${var.spanner_instance_id}"
+  value = var.create_spanner_instance ? (var.spanner_instance_id != "" ? "${local.name_prefix}${var.spanner_instance_id}" : "${local.name_prefix}dcp-instance") : var.spanner_instance_id
 }
 
 output "spanner_database_id" {
-  value = var.create_spanner_db ? google_spanner_database.database[0].name : "${local.name_prefix}${var.spanner_database_id}"
+  value = var.create_spanner_db ? (var.spanner_database_id != "" ? "${local.name_prefix}${var.spanner_database_id}" : "${local.name_prefix}dcp-db") : var.spanner_database_id
 }

--- a/infra/dcp/modules/dcp/outputs.tf
+++ b/infra/dcp/modules/dcp/outputs.tf
@@ -1,0 +1,15 @@
+output "service_url" {
+  value = google_cloud_run_v2_service.dcp_service.uri
+}
+
+output "service_account_email" {
+  value = google_service_account.dcp_runner.email
+}
+
+output "spanner_instance_id" {
+  value = var.create_spanner ? google_spanner_instance.main[0].name : var.spanner_instance_id
+}
+
+output "spanner_database_id" {
+  value = var.create_spanner ? google_spanner_database.database[0].name : var.spanner_database_id
+}

--- a/infra/dcp/modules/dcp/outputs.tf
+++ b/infra/dcp/modules/dcp/outputs.tf
@@ -7,9 +7,9 @@ output "service_account_email" {
 }
 
 output "spanner_instance_id" {
-  value = var.create_spanner ? google_spanner_instance.main[0].name : var.spanner_instance_id
+  value = var.create_spanner_instance ? google_spanner_instance.main[0].name : "${local.name_prefix}${var.spanner_instance_id}"
 }
 
 output "spanner_database_id" {
-  value = var.create_spanner ? google_spanner_database.database[0].name : var.spanner_database_id
+  value = var.create_spanner_db ? google_spanner_database.database[0].name : "${local.name_prefix}${var.spanner_database_id}"
 }

--- a/infra/dcp/modules/dcp/spanner.tf
+++ b/infra/dcp/modules/dcp/spanner.tf
@@ -1,0 +1,18 @@
+resource "google_spanner_instance" "main" {
+  count            = var.create_spanner ? 1 : 0
+  name             = var.spanner_instance_id
+  config           = "regional-${var.region}"
+  display_name     = var.spanner_instance_id
+  processing_units = var.spanner_processing_units
+  force_destroy    = !var.deletion_protection
+
+}
+
+resource "google_spanner_database" "database" {
+  count    = var.create_spanner ? 1 : 0
+  instance = google_spanner_instance.main[0].name
+  name     = var.spanner_database_id
+
+  # Prevent deletion of data
+  deletion_protection = var.deletion_protection
+}

--- a/infra/dcp/modules/dcp/spanner.tf
+++ b/infra/dcp/modules/dcp/spanner.tf
@@ -1,17 +1,17 @@
 resource "google_spanner_instance" "main" {
-  count            = var.create_spanner ? 1 : 0
-  name             = var.spanner_instance_id
+  count            = var.create_spanner_instance ? 1 : 0
+  name             = var.create_spanner_instance ? "${local.name_prefix}${var.spanner_instance_id}" : "unused"
   config           = "regional-${var.region}"
-  display_name     = var.spanner_instance_id
+  display_name     = "${local.name_prefix}${var.spanner_instance_id}"
   processing_units = var.spanner_processing_units
   force_destroy    = !var.deletion_protection
 
 }
 
 resource "google_spanner_database" "database" {
-  count    = var.create_spanner ? 1 : 0
-  instance = google_spanner_instance.main[0].name
-  name     = var.spanner_database_id
+  count    = var.create_spanner_db ? 1 : 0
+  instance = var.create_spanner_instance ? google_spanner_instance.main[0].name : (var.spanner_instance_id != "" ? "${local.name_prefix}${var.spanner_instance_id}" : "unused")
+  name     = "${local.name_prefix}${var.spanner_database_id}"
 
   # Prevent deletion of data
   deletion_protection = var.deletion_protection

--- a/infra/dcp/modules/dcp/spanner.tf
+++ b/infra/dcp/modules/dcp/spanner.tf
@@ -1,8 +1,8 @@
 resource "google_spanner_instance" "main" {
   count            = var.create_spanner_instance ? 1 : 0
-  name             = (var.create_spanner_instance && var.spanner_instance_id != "") ? "${local.name_prefix}${var.spanner_instance_id}" : "unused-instance"
+  name             = var.create_spanner_instance ? (var.spanner_instance_id != "" ? "${local.name_prefix}${var.spanner_instance_id}" : "${local.name_prefix}dcp-instance") : var.spanner_instance_id
   config           = "regional-${var.region}"
-  display_name     = "${local.name_prefix}${var.spanner_instance_id}"
+  display_name     = var.create_spanner_instance ? (var.spanner_instance_id != "" ? "${local.name_prefix}${var.spanner_instance_id}" : "${local.name_prefix}dcp-instance") : var.spanner_instance_id
   processing_units = var.spanner_processing_units
   force_destroy    = !var.deletion_protection
 
@@ -10,8 +10,8 @@ resource "google_spanner_instance" "main" {
 
 resource "google_spanner_database" "database" {
   count    = var.create_spanner_db ? 1 : 0
-  instance = var.create_spanner_instance ? google_spanner_instance.main[0].name : (var.spanner_instance_id != "" ? "${local.name_prefix}${var.spanner_instance_id}" : "unused-instance")
-  name     = "${local.name_prefix}${var.spanner_database_id}"
+  instance = var.create_spanner_instance ? google_spanner_instance.main[0].name : (var.spanner_instance_id != "" ? var.spanner_instance_id : "unused-instance")
+  name     = var.create_spanner_db ? (var.spanner_database_id != "" ? "${local.name_prefix}${var.spanner_database_id}" : "${local.name_prefix}dcp-db") : var.spanner_database_id
 
   # Prevent deletion of data
   deletion_protection = var.deletion_protection

--- a/infra/dcp/modules/dcp/spanner.tf
+++ b/infra/dcp/modules/dcp/spanner.tf
@@ -1,6 +1,6 @@
 resource "google_spanner_instance" "main" {
   count            = var.create_spanner_instance ? 1 : 0
-  name             = var.create_spanner_instance ? "${local.name_prefix}${var.spanner_instance_id}" : "unused"
+  name             = (var.create_spanner_instance && var.spanner_instance_id != "") ? "${local.name_prefix}${var.spanner_instance_id}" : "unused-instance"
   config           = "regional-${var.region}"
   display_name     = "${local.name_prefix}${var.spanner_instance_id}"
   processing_units = var.spanner_processing_units
@@ -10,7 +10,7 @@ resource "google_spanner_instance" "main" {
 
 resource "google_spanner_database" "database" {
   count    = var.create_spanner_db ? 1 : 0
-  instance = var.create_spanner_instance ? google_spanner_instance.main[0].name : (var.spanner_instance_id != "" ? "${local.name_prefix}${var.spanner_instance_id}" : "unused")
+  instance = var.create_spanner_instance ? google_spanner_instance.main[0].name : (var.spanner_instance_id != "" ? "${local.name_prefix}${var.spanner_instance_id}" : "unused-instance")
   name     = "${local.name_prefix}${var.spanner_database_id}"
 
   # Prevent deletion of data

--- a/infra/dcp/modules/dcp/variables.tf
+++ b/infra/dcp/modules/dcp/variables.tf
@@ -1,3 +1,8 @@
+variable "namespace" {
+  description = "Global prefix for resources"
+  type        = string
+}
+
 variable "project_id" {
   description = "GCP Project ID"
   type        = string
@@ -23,8 +28,13 @@ variable "service_account_name" {
   type        = string
 }
 
-variable "create_spanner" {
-  description = "Whether to create a new Spanner instance and database"
+variable "create_spanner_instance" {
+  description = "Whether to create a new Spanner instance"
+  type        = bool
+}
+
+variable "create_spanner_db" {
+  description = "Whether to create a new Spanner database"
   type        = bool
 }
 
@@ -43,33 +53,33 @@ variable "spanner_processing_units" {
   type        = number
 }
 
-variable "cpu" {
-  description = "Number of CPUs"
+variable "service_cpu" {
+  description = "CPU limit for the service container"
   type        = string
 }
 
-variable "memory" {
-  description = "Amount of Memory"
+variable "service_memory" {
+  description = "Memory limit for the service container"
   type        = string
 }
 
-variable "min_instances" {
-  description = "Minimum number of instances"
+variable "service_min_instances" {
+  description = "Minimum number of service instances"
   type        = number
 }
 
-variable "max_instances" {
-  description = "Maximum number of instances"
+variable "service_max_instances" {
+  description = "Maximum number of service instances"
   type        = number
 }
 
-variable "concurrency" {
-  description = "Maximum concurrent requests per instance"
+variable "service_concurrency" {
+  description = "Maximum concurrent requests per service instance"
   type        = number
 }
 
-variable "timeout_seconds" {
-  description = "Request timeout in seconds"
+variable "service_timeout_seconds" {
+  description = "Request timeout in seconds for the service"
   type        = number
 }
 

--- a/infra/dcp/modules/dcp/variables.tf
+++ b/infra/dcp/modules/dcp/variables.tf
@@ -1,0 +1,79 @@
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP Region"
+  type        = string
+}
+
+variable "image_url" {
+  description = "Docker image URL to deploy"
+  type        = string
+}
+
+variable "service_name" {
+  description = "Name of the Cloud Run service"
+  type        = string
+}
+
+variable "service_account_name" {
+  description = "Name of the Service Account to create/use"
+  type        = string
+}
+
+variable "create_spanner" {
+  description = "Whether to create a new Spanner instance and database"
+  type        = bool
+}
+
+variable "spanner_instance_id" {
+  description = "Spanner Instance ID"
+  type        = string
+}
+
+variable "spanner_database_id" {
+  description = "Spanner Database ID"
+  type        = string
+}
+
+variable "spanner_processing_units" {
+  description = "Spanner Processing Units"
+  type        = number
+}
+
+variable "cpu" {
+  description = "Number of CPUs"
+  type        = string
+}
+
+variable "memory" {
+  description = "Amount of Memory"
+  type        = string
+}
+
+variable "min_instances" {
+  description = "Minimum number of instances"
+  type        = number
+}
+
+variable "max_instances" {
+  description = "Maximum number of instances"
+  type        = number
+}
+
+variable "concurrency" {
+  description = "Maximum concurrent requests per instance"
+  type        = number
+}
+
+variable "timeout_seconds" {
+  description = "Request timeout in seconds"
+  type        = number
+}
+
+variable "deletion_protection" {
+  description = "Enable deletion protection"
+  type        = bool
+}

--- a/infra/dcp/outputs.tf
+++ b/infra/dcp/outputs.tf
@@ -1,0 +1,17 @@
+# --- DCP Outputs ---
+output "dcp_service_url" {
+  value = var.enable_dcp ? module.dcp[0].service_url : null
+}
+
+output "dcp_spanner_instance_id" {
+  value = var.enable_dcp ? module.dcp[0].spanner_instance_id : null
+}
+
+# --- CDC Outputs ---
+output "cdc_service_url" {
+  value = var.enable_cdc ? module.cdc[0].cloud_run_service_url : null
+}
+
+output "cdc_mysql_instance_connection_name" {
+  value = var.enable_cdc ? module.cdc[0].mysql_instance_connection_name : null
+}

--- a/infra/dcp/setup.sh
+++ b/infra/dcp/setup.sh
@@ -13,49 +13,53 @@ if [ ! -f terraform.tfvars ]; then
     echo "⚠️  Warning: No terraform.tfvars file found. You might want to copy terraform.tfvars.example to terraform.tfvars first."
 fi
 
-# Prompt for bucket name
-read -p "Enter the name of your GCS Terraform State Bucket: " BUCKET_NAME
+# Prompt whether to use remote state
+read -p "Do you want to configure remote state storage in GCS? (y/N): " USE_REMOTE_STATE
 
-if [ -z "$BUCKET_NAME" ]; then
-    echo "Error: Bucket name cannot be empty."
-    exit 1
-fi
+if [[ "$USE_REMOTE_STATE" =~ ^[Yy]$ ]]; then
+    # Prompt for bucket name
+    read -p "Enter the name of your GCS Terraform State Bucket: " BUCKET_NAME
 
-# Prioritize project_id from terraform.tfvars if it exists
-if [ -f terraform.tfvars ]; then
-    PROJECT_ID=$(grep "^project_id" terraform.tfvars | awk -F'=' '{print $2}' | tr -d ' "')
-fi
+    if [ -z "$BUCKET_NAME" ]; then
+        echo "Error: Bucket name cannot be empty."
+        exit 1
+    fi
 
-# Fallback to .env (for backward compatibility during transition)
-if [ -z "$PROJECT_ID" ] && [ -f .env ]; then
-    PROJECT_ID=$(grep "^TF_VAR_project_id" .env | awk -F'=' '{print $2}' | tr -d ' "')
-fi
+    # Prioritize project_id from terraform.tfvars if it exists
+    if [ -f terraform.tfvars ]; then
+        PROJECT_ID=$(grep "^project_id" terraform.tfvars | awk -F'=' '{print $2}' | tr -d ' "')
+    fi
 
-# Fallback to GOOGLE_CLOUD_PROJECT
-if [ -z "$PROJECT_ID" ] && [ -n "$GOOGLE_CLOUD_PROJECT" ]; then
-    PROJECT_ID="$GOOGLE_CLOUD_PROJECT"
-fi
+    # Fallback to .env (for backward compatibility during transition)
+    if [ -z "$PROJECT_ID" ] && [ -f .env ]; then
+        PROJECT_ID=$(grep "^TF_VAR_project_id" .env | awk -F'=' '{print $2}' | tr -d ' "')
+    fi
 
-# Final prompting if still missing
-if [ -z "$PROJECT_ID" ]; then
-    read -p "Enter your Google Cloud Project ID: " PROJECT_ID
-fi
+    # Fallback to GOOGLE_CLOUD_PROJECT
+    if [ -z "$PROJECT_ID" ] && [ -n "$GOOGLE_CLOUD_PROJECT" ]; then
+        PROJECT_ID="$GOOGLE_CLOUD_PROJECT"
+    fi
 
-# Create the bucket if it doesn't exist
-echo "Checking bucket gs://${BUCKET_NAME}..."
-if ! gcloud storage buckets describe "gs://${BUCKET_NAME}" --project="${PROJECT_ID}" &>/dev/null; then
-    echo "Creating bucket gs://${BUCKET_NAME} in ${PROJECT_ID}..."
-    gcloud storage buckets create "gs://${BUCKET_NAME}" --project="${PROJECT_ID}" --location=us --uniform-bucket-level-access
-    
-    echo "Enabling versioning on gs://${BUCKET_NAME}..."
-    gcloud storage buckets update "gs://${BUCKET_NAME}" --versioning
-else
-    echo "Bucket gs://${BUCKET_NAME} already exists."
-fi
+    # Final prompting if still missing
+    if [ -z "$PROJECT_ID" ]; then
+        read -p "Enter your Google Cloud Project ID: " PROJECT_ID
+    fi
 
-# Generate the backend.tf file dynamically
-echo "Generating backend.tf..."
-cat <<EOF > backend.tf
+    # Create the bucket if it doesn't exist
+    echo "Checking bucket gs://${BUCKET_NAME}..."
+    if ! gcloud storage buckets describe "gs://${BUCKET_NAME}" --project="${PROJECT_ID}" &>/dev/null; then
+        echo "Creating bucket gs://${BUCKET_NAME} in ${PROJECT_ID}..."
+        gcloud storage buckets create "gs://${BUCKET_NAME}" --project="${PROJECT_ID}" --location=us --uniform-bucket-level-access
+        
+        echo "Enabling versioning on gs://${BUCKET_NAME}..."
+        gcloud storage buckets update "gs://${BUCKET_NAME}" --versioning
+    else
+        echo "Bucket gs://${BUCKET_NAME} already exists."
+    fi
+
+    # Generate the backend.tf file dynamically
+    echo "Generating backend.tf..."
+    cat <<EOF > backend.tf
 terraform {
   backend "gcs" {
     bucket = "${BUCKET_NAME}"
@@ -64,7 +68,14 @@ terraform {
 }
 EOF
 
-echo "✅ backend.tf created successfully!"
+    echo "✅ backend.tf created successfully!"
+else
+    echo "Skipping remote state setup. Local state will be used."
+    if [ -f backend.tf ]; then
+        echo "Removing existing backend.tf..."
+        rm backend.tf
+    fi
+fi
 echo "Now running terraform init..."
 terraform init
 

--- a/infra/dcp/setup.sh
+++ b/infra/dcp/setup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# setup.sh
+# Configures the Terraform GCS Backend for state storage.
+
+set -e
+
+echo "Welcome to the Data Commons Infrastructure Setup!"
+echo "This script will configure your Terraform state to be stored in a Google Cloud Storage bucket."
+echo ""
+
+# Check for terraform.tfvars file
+if [ ! -f terraform.tfvars ]; then
+    echo "⚠️  Warning: No terraform.tfvars file found. You might want to copy terraform.tfvars.example to terraform.tfvars first."
+fi
+
+# Prompt for bucket name
+read -p "Enter the name of your GCS Terraform State Bucket: " BUCKET_NAME
+
+if [ -z "$BUCKET_NAME" ]; then
+    echo "Error: Bucket name cannot be empty."
+    exit 1
+fi
+
+# Prioritize project_id from terraform.tfvars if it exists
+if [ -f terraform.tfvars ]; then
+    PROJECT_ID=$(grep "^project_id" terraform.tfvars | awk -F'=' '{print $2}' | tr -d ' "')
+fi
+
+# Fallback to .env (for backward compatibility during transition)
+if [ -z "$PROJECT_ID" ] && [ -f .env ]; then
+    PROJECT_ID=$(grep "^TF_VAR_project_id" .env | awk -F'=' '{print $2}' | tr -d ' "')
+fi
+
+# Fallback to GOOGLE_CLOUD_PROJECT
+if [ -z "$PROJECT_ID" ] && [ -n "$GOOGLE_CLOUD_PROJECT" ]; then
+    PROJECT_ID="$GOOGLE_CLOUD_PROJECT"
+fi
+
+# Final prompting if still missing
+if [ -z "$PROJECT_ID" ]; then
+    read -p "Enter your Google Cloud Project ID: " PROJECT_ID
+fi
+
+# Create the bucket if it doesn't exist
+echo "Checking bucket gs://${BUCKET_NAME}..."
+if ! gcloud storage buckets describe "gs://${BUCKET_NAME}" --project="${PROJECT_ID}" &>/dev/null; then
+    echo "Creating bucket gs://${BUCKET_NAME} in ${PROJECT_ID}..."
+    gcloud storage buckets create "gs://${BUCKET_NAME}" --project="${PROJECT_ID}" --location=us --uniform-bucket-level-access
+    
+    echo "Enabling versioning on gs://${BUCKET_NAME}..."
+    gcloud storage buckets update "gs://${BUCKET_NAME}" --versioning
+else
+    echo "Bucket gs://${BUCKET_NAME} already exists."
+fi
+
+# Generate the backend.tf file dynamically
+echo "Generating backend.tf..."
+cat <<EOF > backend.tf
+terraform {
+  backend "gcs" {
+    bucket = "${BUCKET_NAME}"
+    prefix = "terraform/state"
+  }
+}
+EOF
+
+echo "✅ backend.tf created successfully!"
+echo "Now running terraform init..."
+terraform init
+
+echo ""
+echo "Setup complete! You can now run 'terraform apply' to deploy your infrastructure."

--- a/infra/dcp/terraform.tfvars.example
+++ b/infra/dcp/terraform.tfvars.example
@@ -4,12 +4,16 @@ namespace           = "techsoup"
 
 # --- Stack Toggles ---
 enable_dcp                  = true
-enable_cdc                  = false
+enable_cdc                  = true
 
 # Only set to true if you need to create a dedicated Spanner Instance (Expensive!)
 # Otherwise, provide an existing instance ID in dcp_spanner_instance_id
 dcp_create_spanner_instance = false
 
 # --- CDC Stack Variables (Legacy) ---
-# cdc_dc_api_key        = "your-dc-api-key"
+# cdc_dc_api_key        = "your-dc-api-key"  # You can get this from https://apikeys.datacommons.org
 # cdc_maps_api_key      = "your-maps-api-key"
+
+# When deploying to a shared project, override this to avoid VPC Peering conflicts
+# Examples: "10.13.0.0/28", "10.14.0.0/28", "10.15.0.0/28"
+# cdc_vpc_connector_cidr = "10.13.0.0/28"

--- a/infra/dcp/terraform.tfvars.example
+++ b/infra/dcp/terraform.tfvars.example
@@ -12,8 +12,11 @@ dcp_create_spanner_instance = false
 
 # --- CDC Stack Variables (Legacy) ---
 # cdc_dc_api_key        = "your-dc-api-key"  # You can get this from https://apikeys.datacommons.org
-# cdc_maps_api_key      = "your-maps-api-key"
 
 # When deploying to a shared project, override this to avoid VPC Peering conflicts
 # Examples: "10.13.0.0/28", "10.14.0.0/28", "10.15.0.0/28"
 # cdc_vpc_connector_cidr = "10.13.0.0/28"
+
+# --- Billing Config ---
+# user_project_override = true
+# billing_project_id    = "your-billing-project-id"

--- a/infra/dcp/terraform.tfvars.example
+++ b/infra/dcp/terraform.tfvars.example
@@ -1,20 +1,15 @@
 # --- Shared Global Variables ---
 project_id          = "your-project-id"
-region              = "us-central1"
-deletion_protection = false
+namespace           = "techsoup"
 
 # --- Stack Toggles ---
-enable_dcp          = true
-enable_cdc          = false
+enable_dcp                  = true
+enable_cdc                  = false
 
-# --- DCP Stack Variables ---
-dcp_image_url           = "gcr.io/your-project/datacommons-platform:latest"
-dcp_service_name        = "datacommons-platform"
-dcp_service_account_name = "dcp-runner-sa"
-dcp_create_spanner       = true
+# Only set to true if you need to create a dedicated Spanner Instance (Expensive!)
+# Otherwise, provide an existing instance ID in dcp_spanner_instance_id
+dcp_create_spanner_instance = false
 
 # --- CDC Stack Variables (Legacy) ---
-# cdc_namespace         = "cdc"
 # cdc_dc_api_key        = "your-dc-api-key"
 # cdc_maps_api_key      = "your-maps-api-key"
-# cdc_enable_redis      = false

--- a/infra/dcp/terraform.tfvars.example
+++ b/infra/dcp/terraform.tfvars.example
@@ -1,0 +1,20 @@
+# --- Shared Global Variables ---
+project_id          = "your-project-id"
+region              = "us-central1"
+deletion_protection = false
+
+# --- Stack Toggles ---
+enable_dcp          = true
+enable_cdc          = false
+
+# --- DCP Stack Variables ---
+dcp_image_url           = "gcr.io/your-project/datacommons-platform:latest"
+dcp_service_name        = "datacommons-platform"
+dcp_service_account_name = "dcp-runner-sa"
+dcp_create_spanner       = true
+
+# --- CDC Stack Variables (Legacy) ---
+# cdc_namespace         = "cdc"
+# cdc_dc_api_key        = "your-dc-api-key"
+# cdc_maps_api_key      = "your-maps-api-key"
+# cdc_enable_redis      = false

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -10,6 +10,18 @@ variable "region" {
   default     = "us-central1"
 }
 
+variable "user_project_override" {
+  description = "Set to true to specify a quota / billing project with billing_project_id. Default: true."
+  type        = bool
+  default     = true
+}
+
+variable "billing_project_id" {
+  description = "If user_project_override is set to true, will use this billing project id. Default: null (will use var.project_id as the billing project)"
+  type        = string
+  default     = null
+}
+
 variable "deletion_protection" {
   description = "Enable deletion protection for resources (set to true for production)"
   type        = bool
@@ -93,7 +105,7 @@ variable "dcp_service_memory" {
 variable "dcp_service_min_instances" {
   description = "Minimum number of instances for the DCP service"
   type        = number
-  default     = 0
+  default     = 1
 }
 
 variable "dcp_service_max_instances" {

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -39,31 +39,37 @@ variable "dcp_image_url" {
 variable "dcp_service_name" {
   description = "Cloud Run service name for DCP"
   type        = string
-  default     = "datacommons-platform"
+  default     = "dcp-svc"
 }
 
 variable "dcp_service_account_name" {
   description = "Service account for DCP"
   type        = string
-  default     = "dcp-runner-sa"
+  default     = "dcp-sa"
 }
 
-variable "dcp_create_spanner" {
-  description = "Create Spanner for DCP"
+variable "dcp_create_spanner_instance" {
+  description = "Create a new Spanner instance for DCP"
   type        = bool
   default     = false
+}
+
+variable "dcp_create_spanner_db" {
+  description = "Create a new Spanner database for DCP"
+  type        = bool
+  default     = true
 }
 
 variable "dcp_spanner_instance_id" {
   description = "Spanner instance for DCP"
   type        = string
-  default     = "dcp-spanner-instance"
+  default     = ""
 }
 
 variable "dcp_spanner_database_id" {
   description = "Spanner database for DCP"
   type        = string
-  default     = "dcp-spanner-db"
+  default     = "dcp-db"
 }
 
 variable "dcp_spanner_processing_units" {
@@ -72,47 +78,46 @@ variable "dcp_spanner_processing_units" {
   default     = 100
 }
 
-variable "dcp_cpu" {
-  description = "DCP CPU"
+variable "dcp_service_cpu" {
+  description = "CPU limit for the DCP service container"
   type        = string
   default     = "1000m"
 }
 
-variable "dcp_memory" {
-  description = "DCP Memory"
+variable "dcp_service_memory" {
+  description = "Memory limit for the DCP service container"
   type        = string
   default     = "512Mi"
 }
 
-variable "dcp_min_instances" {
-  description = "DCP min instances"
+variable "dcp_service_min_instances" {
+  description = "Minimum number of instances for the DCP service"
   type        = number
   default     = 0
 }
 
-variable "dcp_max_instances" {
-  description = "DCP max instances"
+variable "dcp_service_max_instances" {
+  description = "Maximum number of instances for the DCP service"
   type        = number
   default     = 10
 }
 
-variable "dcp_concurrency" {
-  description = "DCP concurrency"
+variable "dcp_service_concurrency" {
+  description = "Maximum concurrent requests per instance for the DCP service"
   type        = number
   default     = 80
 }
 
-variable "dcp_timeout_seconds" {
-  description = "DCP timeout"
+variable "dcp_service_timeout_seconds" {
+  description = "Request timeout in seconds for the DCP service"
   type        = number
   default     = 300
 }
 
-# --- CDC Stack Variables (Legacy) ---
-variable "cdc_namespace" {
-  description = "Prefix for CDC resources"
+variable "namespace" {
+  description = "Global prefix for all resources"
   type        = string
-  default     = "cdc"
+  default     = ""
 }
 
 variable "cdc_dc_api_key" {
@@ -166,7 +171,7 @@ variable "cdc_gcs_data_bucket_location" {
 variable "cdc_mysql_instance_name" {
   description = "CDC MySQL name"
   type        = string
-  default     = "datacommons-mysql-instance"
+  default     = "sql-inst"
 }
 
 variable "cdc_mysql_database_name" {

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -1,0 +1,338 @@
+# --- Shared Global Variables ---
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP Region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "deletion_protection" {
+  description = "Enable deletion protection for resources (set to true for production)"
+  type        = bool
+  default     = false
+}
+
+# --- Stack Toggles ---
+variable "enable_dcp" {
+  description = "Enable the new Data Commons Platform stack"
+  type        = bool
+  default     = false
+}
+
+variable "enable_cdc" {
+  description = "Enable the legacy Custom Data Commons stack"
+  type        = bool
+  default     = true
+}
+
+# --- DCP Stack Variables ---
+variable "dcp_image_url" {
+  description = "Docker image URL for DCP"
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-platform:latest"
+}
+
+variable "dcp_service_name" {
+  description = "Cloud Run service name for DCP"
+  type        = string
+  default     = "datacommons-platform"
+}
+
+variable "dcp_service_account_name" {
+  description = "Service account for DCP"
+  type        = string
+  default     = "dcp-runner-sa"
+}
+
+variable "dcp_create_spanner" {
+  description = "Create Spanner for DCP"
+  type        = bool
+  default     = false
+}
+
+variable "dcp_spanner_instance_id" {
+  description = "Spanner instance for DCP"
+  type        = string
+  default     = "dcp-spanner-instance"
+}
+
+variable "dcp_spanner_database_id" {
+  description = "Spanner database for DCP"
+  type        = string
+  default     = "dcp-spanner-db"
+}
+
+variable "dcp_spanner_processing_units" {
+  description = "Spanner units for DCP"
+  type        = number
+  default     = 100
+}
+
+variable "dcp_cpu" {
+  description = "DCP CPU"
+  type        = string
+  default     = "1000m"
+}
+
+variable "dcp_memory" {
+  description = "DCP Memory"
+  type        = string
+  default     = "512Mi"
+}
+
+variable "dcp_min_instances" {
+  description = "DCP min instances"
+  type        = number
+  default     = 0
+}
+
+variable "dcp_max_instances" {
+  description = "DCP max instances"
+  type        = number
+  default     = 10
+}
+
+variable "dcp_concurrency" {
+  description = "DCP concurrency"
+  type        = number
+  default     = 80
+}
+
+variable "dcp_timeout_seconds" {
+  description = "DCP timeout"
+  type        = number
+  default     = 300
+}
+
+# --- CDC Stack Variables (Legacy) ---
+variable "cdc_namespace" {
+  description = "Prefix for CDC resources"
+  type        = string
+  default     = "cdc"
+}
+
+variable "cdc_dc_api_key" {
+  description = "DC API Key for CDC"
+  type        = string
+  default     = ""
+}
+
+variable "cdc_maps_api_key" {
+  description = "Maps API Key for CDC"
+  type        = string
+  default     = null
+}
+
+variable "cdc_disable_google_maps" {
+  description = "Disable maps in CDC"
+  type        = bool
+  default     = false
+}
+
+variable "cdc_google_analytics_tag_id" {
+  description = "GA tag for CDC"
+  type        = string
+  default     = null
+}
+
+variable "cdc_gcs_data_bucket_name" {
+  description = "CDC data bucket"
+  type        = string
+  default     = ""
+}
+
+variable "cdc_gcs_data_bucket_input_folder" {
+  description = "CDC input folder"
+  type        = string
+  default     = "input"
+}
+
+variable "cdc_gcs_data_bucket_output_folder" {
+  description = "CDC output folder"
+  type        = string
+  default     = "output"
+}
+
+variable "cdc_gcs_data_bucket_location" {
+  description = "CDC bucket location"
+  type        = string
+  default     = "US"
+}
+
+variable "cdc_mysql_instance_name" {
+  description = "CDC MySQL name"
+  type        = string
+  default     = "datacommons-mysql-instance"
+}
+
+variable "cdc_mysql_database_name" {
+  description = "CDC MySQL DB name"
+  type        = string
+  default     = "datacommons"
+}
+
+variable "cdc_mysql_database_version" {
+  description = "CDC MySQL version"
+  type        = string
+  default     = "MYSQL_8_0"
+}
+
+variable "cdc_mysql_cpu_count" {
+  description = "CDC MySQL CPU"
+  type        = number
+  default     = 2
+}
+
+variable "cdc_mysql_memory_size_mb" {
+  description = "CDC MySQL RAM"
+  type        = number
+  default     = 7680
+}
+
+variable "cdc_mysql_storage_size_gb" {
+  description = "CDC MySQL Disk"
+  type        = number
+  default     = 20
+}
+
+variable "cdc_mysql_user" {
+  description = "CDC MySQL user"
+  type        = string
+  default     = "datacommons"
+}
+
+variable "cdc_vpc_connector_cidr" {
+  description = "CIDR range for the CDC VPC Access Connector"
+  type        = string
+  default     = "10.13.0.0/28"
+}
+
+variable "cdc_web_service_image" {
+  description = "CDC web image"
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-services:stable"
+}
+
+variable "cdc_web_service_min_instance_count" {
+  description = "CDC min instances"
+  type        = number
+  default     = 1
+}
+
+variable "cdc_web_service_max_instance_count" {
+  description = "CDC max instances"
+  type        = number
+  default     = 1
+}
+
+variable "cdc_web_service_cpu" {
+  description = "CDC web CPU"
+  type        = string
+  default     = "4"
+}
+
+variable "cdc_web_service_memory" {
+  description = "CDC web RAM"
+  type        = string
+  default     = "16G"
+}
+
+variable "cdc_make_dc_web_service_public" {
+  description = "CDC public access"
+  type        = bool
+  default     = true
+}
+
+variable "cdc_data_job_image" {
+  description = "CDC data job image"
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-data:stable"
+}
+
+variable "cdc_data_job_cpu" {
+  description = "CDC data job CPU"
+  type        = string
+  default     = "2"
+}
+
+variable "cdc_data_job_memory" {
+  description = "CDC data job RAM"
+  type        = string
+  default     = "8G"
+}
+
+variable "cdc_data_job_timeout" {
+  description = "CDC data job timeout"
+  type        = string
+  default     = "600s"
+}
+
+variable "cdc_search_scope" {
+  description = "CDC search scope"
+  type        = string
+  default     = "base_and_custom"
+}
+
+variable "cdc_enable_mcp" {
+  description = "CDC enable MCP"
+  type        = bool
+  default     = true
+}
+
+variable "cdc_vpc_network_name" {
+  description = "CDC VPC network"
+  type        = string
+  default     = "default"
+}
+
+variable "cdc_vpc_network_subnet_name" {
+  description = "CDC VPC subnet"
+  type        = string
+  default     = "default"
+}
+
+variable "cdc_enable_redis" {
+  description = "CDC enable redis"
+  type        = bool
+  default     = false
+}
+
+variable "cdc_redis_instance_name" {
+  description = "CDC redis name"
+  type        = string
+  default     = "datacommons-redis-instance"
+}
+
+variable "cdc_redis_memory_size_gb" {
+  description = "CDC redis size"
+  type        = number
+  default     = 2
+}
+
+variable "cdc_redis_tier" {
+  description = "CDC redis tier"
+  type        = string
+  default     = "STANDARD_HA"
+}
+
+variable "cdc_redis_location_id" {
+  description = "CDC redis zone"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "cdc_redis_alternative_location_id" {
+  description = "CDC redis alt zone"
+  type        = string
+  default     = "us-central1-b"
+}
+
+variable "cdc_redis_replica_count" {
+  description = "CDC redis replicas"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
This group of terraform script controls the setup of a new Data Commons Platform deployment within a GCP Project that has nothing setup.

- Enables the Spanner, Cloud Run and IAM APIs
- Creates a Service Account, with databaseUser permission 
- Creates a Cloud Run Service, deploying the :latest datacommons-platform image and grants it AllUsers Invoker permissions
- Creates a Spanner Instance and DB

Note that after running this in datcom-website-dev, we succeeded with each of the following resources:
- DCP Service Account - [🔗](https://pantheon.corp.google.com/iam-admin/serviceaccounts/details/103873044663480688789?e=13803378&inv=1&invt=Ab4PUA&mods=-monitoring_api_staging&project=datcom-website-dev)
- DCP Cloud Run Service - [🔗 ](https://pantheon.corp.google.com/run/detail/us-central1/gmechali-datacommons-platform-test1/observability/metrics?e=13803378&inv=1&invt=Ab4PUA&mods=-monitoring_api_staging&project=datcom-website-dev)
- Spanner Instance [🔗](https://pantheon.corp.google.com/spanner/instances/gmechali-test1-instance/details/databases?e=13803378&inv=1&invt=Ab4PUA&mods=-monitoring_api_staging&project=datcom-website-dev)  and DB [🔗](https://pantheon.corp.google.com/spanner/instances/gmechali-test1-instance/databases/gmechali-test1-db/details/tables?e=13803378&inv=1&invt=Ab4PUA&mods=-monitoring_api_staging&project=datcom-website-dev)


And after running the commands in the DCP setup: https://github.com/datacommonsorg/datacommons?tab=readme-ov-file#2-define-your-schema but changing the URL to the new Cloud Run Service, you can inspect the logs to find the requests, and inspect the DB to find the schema and nodes successfully saved!


Note - I have added more optional variables to control the Spanner DB + cloud run service setup but have not yet tested them. Thoughts on including those? 

Lastly, it adds a setup script to create the GCS bucket for remote state management.