### PR TITLE
[DCP Deployment] Update Dockerfile for UV pinning & nonroot access

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 
-# Install uv.
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+# Install uv. Pinning version for reproducibility.
+COPY --from=ghcr.io/astral-sh/uv:0.9.10 /uv /bin/uv
 
 # Set working directory
 WORKDIR /app
@@ -12,14 +12,16 @@ COPY pyproject.toml uv.lock ./
 # Copy the package directories
 COPY packages/ ./packages/
 
-# Install the dependencies, strictly from the lockfile
-RUN uv sync --frozen --no-dev --no-install-project
-
-# Install the project itself
+# Install the dependencies and the project itself
+# uv sync --frozen installs everything from the lockfile.
 RUN uv sync --frozen --no-dev
 
 # Place the virtualenv in the PATH
 ENV PATH="/app/.venv/bin:$PATH"
+
+# Create a non-root user and switch to it for security
+RUN groupadd -r datacommons-runner && useradd -r -g datacommons-runner datacommons-runner
+USER datacommons-runner
 
 # Expose the API port
 EXPOSE 5000

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,7 +20,7 @@ RUN uv sync --frozen --no-dev
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Create a non-root user and switch to it for security
-RUN groupadd -r datacommons-runner && useradd -r -g datacommons-runner datacommons-runner
+RUN groupadd -r -g 1001 datacommons-runner && useradd -r -g 1001 -u 1001 datacommons-runner
 USER datacommons-runner
 
 # Expose the API port

--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -6,11 +6,11 @@ steps:
       - '-t'
       - 'us-docker.pkg.dev/datcom-ci/gcr.io/datacommons-platform:latest'
       - '-t'
-      - 'us-docker.pkg.dev/datcom-ci/gcr.io/datacommons-platform:$COMMIT_SHA'
+      - 'us-docker.pkg.dev/datcom-ci/gcr.io/datacommons-platform:$SHORT_SHA'
       - '-f'
       - 'build/Dockerfile'
       - '.'
 
 images:
   - 'us-docker.pkg.dev/datcom-ci/gcr.io/datacommons-platform:latest'
-  - 'us-docker.pkg.dev/datcom-ci/gcr.io/datacommons-platform:$COMMIT_SHA'
+  - 'us-docker.pkg.dev/datcom-ci/gcr.io/datacommons-platform:$SHORT_SHA'


### PR DESCRIPTION
Also makes a small change to the cloudbuild to use the SHORT_SHA notation that github supports for the triggers to catch the git commit hash.