### PR TITLE
[DCP Ingestion - Stale Reads] Enable Stale Reads in CDC Web server which runs mixer

### DIFF
--- a/infra/dcp/modules/cdc/locals.tf
+++ b/infra/dcp/modules/cdc/locals.tf
@@ -74,7 +74,7 @@ locals {
     },
     {
       name  = "USE_STALE_READS"
-      value = "true"
+      value = var.use_spanner ? "true" : "false"
     }
   ]
 

--- a/infra/dcp/modules/cdc/locals.tf
+++ b/infra/dcp/modules/cdc/locals.tf
@@ -71,10 +71,6 @@ locals {
     {
       name  = "GCP_SPANNER_DATABASE_NAME"
       value = var.spanner_database_id
-    },
-    {
-      name  = "USE_STALE_READS"
-      value = var.use_spanner ? "true" : "false"
     }
   ]
 

--- a/infra/dcp/modules/cdc/locals.tf
+++ b/infra/dcp/modules/cdc/locals.tf
@@ -71,6 +71,10 @@ locals {
     {
       name  = "GCP_SPANNER_DATABASE_NAME"
       value = var.spanner_database_id
+    },
+    {
+      name  = "USE_STALE_READS"
+      value = "true"
     }
   ]
 

--- a/infra/dcp/modules/cdc/main.tf
+++ b/infra/dcp/modules/cdc/main.tf
@@ -263,11 +263,6 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
       }
 
       env {
-        name  = "USE_STALE_READS"
-        value = (var.use_spanner && var.spanner_instance_id != "" && var.spanner_database_id != "") ? "true" : "false"
-      }
-
-      env {
         name  = "GCP_PROJECT_ID"
         value = var.project_id
       }

--- a/infra/dcp/modules/cdc/main.tf
+++ b/infra/dcp/modules/cdc/main.tf
@@ -262,6 +262,11 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
         }
       }
 
+      env {
+        name  = "USE_STALE_READS"
+        value = var.use_spanner ? "true" : "false"
+      }
+
       dynamic "env" {
         for_each = local.cloud_run_shared_env_variable_secrets
         content {

--- a/infra/dcp/modules/cdc/main.tf
+++ b/infra/dcp/modules/cdc/main.tf
@@ -264,7 +264,12 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
 
       env {
         name  = "USE_STALE_READS"
-        value = var.use_spanner ? "true" : "false"
+        value = (var.use_spanner && var.spanner_instance_id != "" && var.spanner_database_id != "") ? "true" : "false"
+      }
+
+      env {
+        name  = "GCP_PROJECT_ID"
+        value = var.project_id
       }
 
       dynamic "env" {


### PR DESCRIPTION
This is a very small change to the Terraform script to add the USE_STALE_READS environment variable to the Cloud Run Service running the CDC image. This server startups mixer, and will pass in the right feature flags based on the USE_STALE_READS env variable.

See the complementary change in https://github.com/datacommonsorg/website/pull/6215

Currently deployed in https://pantheon.corp.google.com/run/detail/us-central1/gabe-test-datacommons-web-service/observability/logs?e=13803378&inv=1&invt=Ab1zPA&mods=-monitoring_api_staging&project=datcom-website-dev