### PR TITLE
[DCP - Ingestion] Reorganizes the Ingestion Workflow

### DIFF
--- a/infra/dcp/modules/dcp/dataflow.tf
+++ b/infra/dcp/modules/dcp/dataflow.tf
@@ -18,6 +18,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
             - bucket_name: '$${text.split(input.tempLocation, "/")[2]}'
             - latest_version_gcs_path: '$${"gs://" + bucket_name + "/imports/" + input.importName + "/" + version}'
             - execution_error: null
+            - lock_timeout: '$${"lockTimeout" in keys(input) ? int(input.lockTimeout) : ${var.ingestion_lock_timeout}}'
             - launch_params:
                 projectId: '$${project_id}'
                 spannerInstanceId: '$${input.spannerInstanceId}'
@@ -34,7 +35,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
               body:
                 actionType: "acquire_ingestion_lock"
                 workflowId: '$${workflow_id}'
-                timeout: 3600
+                timeout: '$${lock_timeout}'
             result: lock_result
           retry:
             predicate: '$${http.default_retry_predicate}'
@@ -96,7 +97,8 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
                   switch:
                     - condition: '$${job_status.currentState == "JOB_STATE_DONE"}'
                       next: promote_version
-                  next: skip_promotion
+              - fail_on_job_status:
+                  raise: '$${ "Dataflow job failed with state: " + job_status.currentState }'
               - promote_version:
                   call: http.post
                   args:
@@ -124,9 +126,6 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
                         - importName: '$${input.importName}'
                           latestVersion: '$${version}'
                   result: history_result
-              - skip_promotion:
-                  assign:
-                    - dummy: 1
           except:
             as: e
             steps:

--- a/infra/dcp/modules/dcp/dataflow.tf
+++ b/infra/dcp/modules/dcp/dataflow.tf
@@ -13,25 +13,140 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
       - init:
           assign:
             - project_id: '${var.project_id}'
+            - workflow_id: '$${sys.get_env("GOOGLE_CLOUD_WORKFLOW_EXECUTION_ID")}'
+            - version: '$${"version-" + string(int(sys.now()))}'
+            - bucket_name: '$${text.split(input.tempLocation, "/")[2]}'
+            - latest_version_gcs_path: '$${"gs://" + bucket_name + "/imports/" + input.importName + "/" + version}'
+            - execution_error: null
             - launch_params:
                 projectId: '$${project_id}'
                 spannerInstanceId: '$${input.spannerInstanceId}'
                 spannerDatabaseId: '$${input.spannerDatabaseId}'
                 importList: '$${input.importList}'
                 tempLocation: '$${input.tempLocation}'
-      - run_flex_template:
-          call: googleapis.dataflow.v1b3.projects.locations.flexTemplates.launch
+      - acquire_lock:
+          try:
+            call: http.post
+            args:
+              url: '${google_cloud_run_v2_service.ingestion_helper[0].uri}'
+              auth:
+                type: OIDC
+              body:
+                actionType: "acquire_ingestion_lock"
+                workflowId: '$${workflow_id}'
+                timeout: 3600
+            result: lock_result
+          retry:
+            predicate: '$${http.default_retry_predicate}'
+            max_retries: 20
+            backoff:
+              initial_delay: 300
+              max_delay: 600
+              multiplier: 2
+      - process_ingestion:
+          try:
+            steps:
+              - set_import_staging:
+                  call: http.post
+                  args:
+                    url: '${google_cloud_run_v2_service.ingestion_helper[0].uri}'
+                    auth:
+                      type: OIDC
+                    body:
+                      actionType: "update_import_status"
+                      importName: '$${input.importName}'
+                      status: "STAGING"
+                      latestVersion: '$${latest_version_gcs_path}'
+                  result: staging_result
+              - run_flex_template:
+                  call: googleapis.dataflow.v1b3.projects.locations.flexTemplates.launch
+                  args:
+                    projectId: '$${project_id}'
+                    location: '$${input.region}'
+                    body:
+                      launchParameter:
+                        jobName: '$${"ingestion-job-" + string(int(sys.now()))}'
+                        containerSpecGcsPath: 'gs://datcom-templates/templates/flex/ingestion.json'
+                        parameters: '$${launch_params}'
+                        environment:
+                          serviceAccountEmail: '${google_service_account.dcp_ingestion_runner[0].email}'
+                  result: launch_result
+              - get_job_id:
+                  assign:
+                    - job_id: '$${launch_result.job.id}'
+              - poll_job:
+                  steps:
+                    - get_status:
+                        call: googleapis.dataflow.v1b3.projects.locations.jobs.get
+                        args:
+                          projectId: '$${project_id}'
+                          location: '$${input.region}'
+                          jobId: '$${job_id}'
+                        result: job_status
+                    - check_terminal:
+                        switch:
+                          - condition: '$${job_status.currentState in ["JOB_STATE_DONE", "JOB_STATE_FAILED", "JOB_STATE_CANCELLED", "JOB_STATE_UPDATED", "JOB_STATE_DRAINED"]}'
+                            next: check_success
+                    - wait_and_retry:
+                        call: sys.sleep
+                        args:
+                          seconds: 60
+                        next: poll_job
+              - check_success:
+                  switch:
+                    - condition: '$${job_status.currentState == "JOB_STATE_DONE"}'
+                      next: promote_version
+                  next: skip_promotion
+              - promote_version:
+                  call: http.post
+                  args:
+                    url: '${google_cloud_run_v2_service.ingestion_helper[0].uri}'
+                    auth:
+                      type: OIDC
+                    body:
+                      actionType: "update_import_version"
+                      importName: '$${input.importName}'
+                      version: '$${version}'
+                      comment: '$${"Auto-promoted by workflow " + workflow_id}'
+                  result: promote_result
+              - update_ingestion_history_step:
+                  call: http.post
+                  args:
+                    url: '${google_cloud_run_v2_service.ingestion_helper[0].uri}'
+                    auth:
+                      type: OIDC
+                    body:
+                      actionType: "update_ingestion_status"
+                      workflowId: '$${workflow_id}'
+                      jobId: '$${job_id}'
+                      status: 'SUCCESS'
+                      importList:
+                        - importName: '$${input.importName}'
+                          latestVersion: '$${version}'
+                  result: history_result
+              - skip_promotion:
+                  assign:
+                    - dummy: 1
+          except:
+            as: e
+            steps:
+              - capture_error:
+                  assign:
+                    - execution_error: '$${e}'
+      - release_lock_step:
+          call: http.post
           args:
-            projectId: '$${project_id}'
-            location: '$${input.region}'
+            url: '${google_cloud_run_v2_service.ingestion_helper[0].uri}'
+            auth:
+              type: OIDC
             body:
-              launchParameter:
-                jobName: '$${"ingestion-job-" + string(int(sys.now()))}'
-                containerSpecGcsPath: 'gs://datcom-templates/templates/flex/ingestion.json'
-                parameters: '$${launch_params}'
-                environment:
-                  serviceAccountEmail: '${google_service_account.dcp_ingestion_runner[0].email}'
-          result: launch_result
+              actionType: "release_ingestion_lock"
+              workflowId: '$${workflow_id}'
+          result: release_lock_result
+      - fail_workflow:
+          switch:
+            - condition: '$${execution_error != null}'
+              raise: '$${execution_error}'
       - return_result:
           return: '$${launch_result}'
   EOF

--- a/infra/dcp/modules/dcp/dataflow.tf
+++ b/infra/dcp/modules/dcp/dataflow.tf
@@ -18,7 +18,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
             - bucket_name: '$${text.split(input.tempLocation, "/")[2]}'
             - latest_version_gcs_path: '$${"gs://" + bucket_name + "/imports/" + input.importName + "/" + version}'
             - execution_error: null
-            - lock_timeout: '$${"lockTimeout" in keys(input) ? int(input.lockTimeout) : ${var.ingestion_lock_timeout}}'
+            - lock_timeout: ${var.ingestion_lock_timeout}
             - launch_params:
                 projectId: '$${project_id}'
                 spannerInstanceId: '$${input.spannerInstanceId}'

--- a/infra/dcp/modules/dcp/iam.tf
+++ b/infra/dcp/modules/dcp/iam.tf
@@ -79,3 +79,12 @@ resource "google_storage_bucket_iam_member" "dynamic_ingestion_bucket_access" {
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.dcp_ingestion_runner[0].email}"
 }
+
+# Grant Workflows permission to invoke the ingestion helper
+resource "google_cloud_run_service_iam_member" "ingestion_helper_invoker" {
+  count    = var.deploy_data_ingestion_workflow ? 1 : 0
+  location = google_cloud_run_v2_service.ingestion_helper[0].location
+  service  = google_cloud_run_v2_service.ingestion_helper[0].name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.dcp_ingestion_runner[0].email}"
+}

--- a/infra/dcp/modules/dcp/ingestion_helper.tf
+++ b/infra/dcp/modules/dcp/ingestion_helper.tf
@@ -1,0 +1,43 @@
+resource "google_cloud_run_v2_service" "ingestion_helper" {
+  count    = var.deploy_data_ingestion_workflow ? 1 : 0
+  name     = "${var.namespace}-ingestion-helper"
+  location = var.region
+  
+  deletion_protection = var.deletion_protection
+
+  template {
+    containers {
+      image = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
+      
+      env {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "FORCE_RESTART"
+        value = timestamp()
+      }
+      env {
+        name  = "SPANNER_PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "SPANNER_INSTANCE_ID"
+        value = var.spanner_instance_id
+      }
+      env {
+        name  = "SPANNER_DATABASE_ID"
+        value = var.create_spanner_db ? (var.spanner_database_id != "" ? "${local.name_prefix}${var.spanner_database_id}" : "${local.name_prefix}dcp-db") : var.spanner_database_id
+      }
+      env {
+        name  = "LOCATION"
+        value = var.region
+      }
+      env {
+        name  = "GCS_BUCKET_ID"
+        value = var.create_ingestion_bucket ? google_storage_bucket.data_ingestion_bucket[0].name : var.external_ingestion_bucket_name
+      }
+    }
+    service_account = google_service_account.dcp_ingestion_runner[0].email
+  }
+}

--- a/infra/dcp/modules/dcp/ingestion_helper.tf
+++ b/infra/dcp/modules/dcp/ingestion_helper.tf
@@ -7,12 +7,14 @@ resource "google_cloud_run_v2_service" "ingestion_helper" {
 
   template {
     containers {
+      # TODO(gmechali): Change this to a stable image.
       image = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
       
       env {
         name  = "PROJECT_ID"
         value = var.project_id
       }
+      # TODO(gmechali): Remove this once we no longer use the :latest image.
       env {
         name  = "FORCE_RESTART"
         value = timestamp()

--- a/infra/dcp/modules/dcp/variables.tf
+++ b/infra/dcp/modules/dcp/variables.tf
@@ -8,6 +8,12 @@ variable "project_id" {
   type        = string
 }
 
+variable "ingestion_lock_timeout" {
+  description = "Timeout for the ingestion lock in seconds"
+  type        = number
+  default     = 82800
+}
+
 variable "region" {
   description = "GCP Region"
   type        = string


### PR DESCRIPTION
Adds the Lock acquisition and release.
Updates the polling job on the dataflow to match how we did it for base DC.
Adds the import management like set the staging entry, then promote it etc.
See the new [workflow](https://pantheon.corp.google.com/workflows/workflow/us-central1/gabe-test-ingestion-orchestrator/source?e=13803378&mods=-monitoring_api_staging&project=datcom-website-dev)