### PR TITLE
[DCP - Spanner Terraform] Small changes to spanner deployment.

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 5.11.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/infra/dcp/modules/dcp/ingestion_helper.tf
+++ b/infra/dcp/modules/dcp/ingestion_helper.tf
@@ -25,7 +25,7 @@ resource "google_cloud_run_v2_service" "ingestion_helper" {
       }
       env {
         name  = "SPANNER_INSTANCE_ID"
-        value = var.spanner_instance_id
+        value = var.create_spanner_instance ? google_spanner_instance.main[0].name : var.spanner_instance_id
       }
       env {
         name  = "SPANNER_DATABASE_ID"

--- a/infra/dcp/modules/dcp/spanner.tf
+++ b/infra/dcp/modules/dcp/spanner.tf
@@ -5,6 +5,7 @@ resource "google_spanner_instance" "main" {
   display_name     = var.create_spanner_instance ? (var.spanner_instance_id != "" ? "${local.name_prefix}${var.spanner_instance_id}" : "${local.name_prefix}dcp-instance") : var.spanner_instance_id
   processing_units = var.spanner_processing_units
   force_destroy    = !var.deletion_protection
+  edition          = "ENTERPRISE"
 
 }
 

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -93,7 +93,7 @@ variable "dcp_spanner_database_id" {
 variable "dcp_spanner_processing_units" {
   description = "Spanner units for DCP"
   type        = number
-  default     = 100
+  default     = 1000
 }
 
 variable "dcp_service_cpu" {


### PR DESCRIPTION
The new schema requires Enterprise Spanner version.
The previously set node count was extemely small (100 processing units = 0.1 nodes). Im setting the default to 1000 aka 1 node, but for real DCP usage, we will likely need to tell customers to bump that up. Guidance TBD. 