### PR TITLE
Populate static Spanner and location variables in ingestion workflow from Terraform

### DIFF
--- a/infra/dcp/modules/dcp_ingestion_workflow/main.tf
+++ b/infra/dcp/modules/dcp_ingestion_workflow/main.tf
@@ -21,12 +21,14 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
             - version: '$${"version-" + string(int(sys.now()))}'
             - bucket_name: '$${text.split(input.tempLocation, "/")[2]}'
             - latest_version_gcs_path: '$${"gs://" + bucket_name + "/imports/" + input.importName + "/" + version}'
+            - spanner_instance_id: '${var.spanner_instance_id}'
+            - spanner_database_id: '${var.spanner_database_id}'
             - execution_error: null
             - lock_timeout: ${var.ingestion_lock_timeout}
             - launch_params:
                 projectId: '$${project_id}'
-                spannerInstanceId: '$${input.spannerInstanceId}'
-                spannerDatabaseId: '$${input.spannerDatabaseId}'
+                spannerInstanceId: '$${spanner_instance_id}'
+                spannerDatabaseId: '$${spanner_database_id}'
                 importList: '$${input.importList}'
                 tempLocation: '$${input.tempLocation}'
       - acquire_lock:
@@ -67,7 +69,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
                   call: googleapis.dataflow.v1b3.projects.locations.flexTemplates.launch
                   args:
                     projectId: '$${project_id}'
-                    location: '$${input.region}'
+                    location: '${var.region}'
                     body:
                       launchParameter:
                         jobName: '$${"ingestion-job-" + string(int(sys.now()))}'
@@ -85,7 +87,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
                         call: googleapis.dataflow.v1b3.projects.locations.jobs.get
                         args:
                           projectId: '$${project_id}'
-                          location: '$${input.region}'
+                          location: '${var.region}'
                           jobId: '$${job_id}'
                         result: job_status
                     - check_terminal:

--- a/infra/dcp/modules/dcp_ingestion_workflow/main.tf
+++ b/infra/dcp/modules/dcp_ingestion_workflow/main.tf
@@ -19,16 +19,18 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
             - project_id: '${var.project_id}'
             - workflow_id: '$${sys.get_env("GOOGLE_CLOUD_WORKFLOW_EXECUTION_ID")}'
             - version: '$${"version-" + string(int(sys.now()))}'
-            - bucket_name: '$${text.split(input.tempLocation, "/")[2]}'
+            - spanner_instance_id: '${var.spanner_instance_id}'
+            - spanner_database_id: '${var.spanner_database_id}'
+            - bucket_name: '${var.ingestion_bucket_name}'
             - latest_version_gcs_path: '$${"gs://" + bucket_name + "/imports/" + input.importName + "/" + version}'
             - execution_error: null
             - lock_timeout: ${var.ingestion_lock_timeout}
             - launch_params:
                 projectId: '$${project_id}'
-                spannerInstanceId: '$${input.spannerInstanceId}'
-                spannerDatabaseId: '$${input.spannerDatabaseId}'
+                spannerInstanceId: '$${spanner_instance_id}'
+                spannerDatabaseId: '$${spanner_database_id}'
                 importList: '$${input.importList}'
-                tempLocation: '$${input.tempLocation}'
+                tempLocation: '$${"gs://" + bucket_name + "/temp/"}'
       - acquire_lock:
           try:
             call: http.post

--- a/infra/dcp/modules/dcp_ingestion_workflow/main.tf
+++ b/infra/dcp/modules/dcp_ingestion_workflow/main.tf
@@ -19,18 +19,16 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
             - project_id: '${var.project_id}'
             - workflow_id: '$${sys.get_env("GOOGLE_CLOUD_WORKFLOW_EXECUTION_ID")}'
             - version: '$${"version-" + string(int(sys.now()))}'
-            - spanner_instance_id: '${var.spanner_instance_id}'
-            - spanner_database_id: '${var.spanner_database_id}'
-            - bucket_name: '${var.ingestion_bucket_name}'
+            - bucket_name: '$${text.split(input.tempLocation, "/")[2]}'
             - latest_version_gcs_path: '$${"gs://" + bucket_name + "/imports/" + input.importName + "/" + version}'
             - execution_error: null
             - lock_timeout: ${var.ingestion_lock_timeout}
             - launch_params:
                 projectId: '$${project_id}'
-                spannerInstanceId: '$${spanner_instance_id}'
-                spannerDatabaseId: '$${spanner_database_id}'
+                spannerInstanceId: '$${input.spannerInstanceId}'
+                spannerDatabaseId: '$${input.spannerDatabaseId}'
                 importList: '$${input.importList}'
-                tempLocation: '$${"gs://" + bucket_name + "/temp/"}'
+                tempLocation: '$${input.tempLocation}'
       - acquire_lock:
           try:
             call: http.post

--- a/infra/dcp/modules/dcp_ingestion_workflow/main.tf
+++ b/infra/dcp/modules/dcp_ingestion_workflow/main.tf
@@ -21,14 +21,12 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
             - version: '$${"version-" + string(int(sys.now()))}'
             - bucket_name: '$${text.split(input.tempLocation, "/")[2]}'
             - latest_version_gcs_path: '$${"gs://" + bucket_name + "/imports/" + input.importName + "/" + version}'
-            - spanner_instance_id: '${var.spanner_instance_id}'
-            - spanner_database_id: '${var.spanner_database_id}'
             - execution_error: null
             - lock_timeout: ${var.ingestion_lock_timeout}
             - launch_params:
                 projectId: '$${project_id}'
-                spannerInstanceId: '$${spanner_instance_id}'
-                spannerDatabaseId: '$${spanner_database_id}'
+                spannerInstanceId: '${var.spanner_instance_id}'
+                spannerDatabaseId: '${var.spanner_database_id}'
                 importList: '$${input.importList}'
                 tempLocation: '$${input.tempLocation}'
       - acquire_lock:

--- a/infra/dcp/modules/dcp_ingestion_workflow/variables.tf
+++ b/infra/dcp/modules/dcp_ingestion_workflow/variables.tf
@@ -33,3 +33,15 @@ variable "ingestion_runner_id" {
 variable "ingestion_runner_email" {
   type = string
 }
+
+variable "spanner_instance_id" {
+  type = string
+}
+
+variable "spanner_database_id" {
+  type = string
+}
+
+variable "ingestion_bucket_name" {
+  type = string
+}

--- a/infra/dcp/modules/dcp_ingestion_workflow/variables.tf
+++ b/infra/dcp/modules/dcp_ingestion_workflow/variables.tf
@@ -41,7 +41,3 @@ variable "spanner_instance_id" {
 variable "spanner_database_id" {
   type = string
 }
-
-variable "ingestion_bucket_name" {
-  type = string
-}

--- a/infra/dcp/modules/dcp_ingestion_workflow/variables.tf
+++ b/infra/dcp/modules/dcp_ingestion_workflow/variables.tf
@@ -33,15 +33,3 @@ variable "ingestion_runner_id" {
 variable "ingestion_runner_email" {
   type = string
 }
-
-variable "spanner_instance_id" {
-  type = string
-}
-
-variable "spanner_database_id" {
-  type = string
-}
-
-variable "ingestion_bucket_name" {
-  type = string
-}

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -213,7 +213,6 @@ module "dcp_ingestion_workflow" {
   ingestion_runner_email = module.dcp_ingestion_dataflow[0].ingestion_runner_email
   spanner_instance_id    = module.spanner[0].spanner_instance_id
   spanner_database_id    = module.spanner[0].spanner_database_id
-  ingestion_bucket_name  = module.storage.dcp_bucket_name
 }
 
 

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -211,6 +211,9 @@ module "dcp_ingestion_workflow" {
   ingestion_helper_uri   = module.dcp_ingestion_helper[0].ingestion_helper_uri
   ingestion_runner_id    = module.dcp_ingestion_dataflow[0].ingestion_runner_id
   ingestion_runner_email = module.dcp_ingestion_dataflow[0].ingestion_runner_email
+  spanner_instance_id    = module.spanner[0].spanner_instance_id
+  spanner_database_id    = module.spanner[0].spanner_database_id
+  ingestion_bucket_name  = module.storage.dcp_bucket_name
 }
 
 

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -211,9 +211,6 @@ module "dcp_ingestion_workflow" {
   ingestion_helper_uri   = module.dcp_ingestion_helper[0].ingestion_helper_uri
   ingestion_runner_id    = module.dcp_ingestion_dataflow[0].ingestion_runner_id
   ingestion_runner_email = module.dcp_ingestion_dataflow[0].ingestion_runner_email
-  spanner_instance_id    = module.spanner[0].spanner_instance_id
-  spanner_database_id    = module.spanner[0].spanner_database_id
-  ingestion_bucket_name  = module.storage.dcp_bucket_name
 }
 
 


### PR DESCRIPTION
Since region and Spanner do not change from workflow run to run, it makes sense to just populate them from Terraform variables rather than requiring the user to input them on every run.

(This can also be done for the bucket name and temp location, but that needs a bit more work.)