### PR TITLE
Fixes for DCP/CDC Terraform configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,32 +338,6 @@ You should see the:
 }
 ```
 
-
-## Deploying Data Commons Platform In GCP
-
-Use the CLI to scaffold a Terraform deployment directory:
-
-```bash
-uv run datacommons infra init
-```
-
-The command will prompt for:
-- GCP project id
-- namespace
-- Data Commons API key
-
-It then creates a new folder with `main.tf`, `terraform.tfvars`, and a deployment `README.md`.
-
-From the generated folder:
-
-```bash
-terraform init
-terraform plan
-terraform apply
-```
-
-For the full infrastructure module and complete variable reference, see the detailed [GCP Infrastructure Guide](infra/dcp/README.md).
-
 ## Schema Tools
 
 Use the `datacommons schema` command to convert between MCF and JSON-LD formats.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Data Commons powers [datacommons.org](https://datacommons.org), Google's open kn
 
 ## Getting Started
 
-This guide covers setting up Data Commons locally and in Google Cloud Platform (GCP), defining schemas in JSON-LD, adding data via the command-line interface, and querying relationships.
+This guide covers setting up a local Data Commons, defining schemas in JSON-LD, adding data via the command-line interface, and querying relationships.
+
+For deploying Data Commons to Google Cloud Platform (GCP) using Terraform, please refer to the detailed [GCP Infrastructure Guide](infra/dcp/README.md).
 
 ## Prerequisites
 
@@ -21,11 +23,11 @@ Before you begin, ensure you have the following installed:
 - A Google Cloud Platform (GCP) project with Cloud Spanner enabled
 - A Cloud Spanner instance and database (using Google Standard SQL) for storing the knowledge graph
 
-## Setting Up Data Commons Locally
+## Setting Up Data Commons
 
 This section will guide you through setting up Data Commons locally and defining your first custom schema and data.
 
-### 1. Install Data Commons
+### 1. Install Data Commons Locally
 
 To get started, you'll need to check out the Data Commons repository and set up your local environment.
 
@@ -338,7 +340,7 @@ You should see the:
 }
 ```
 
-## Schema Tools
+### Schema Tools
 
 Use the `datacommons schema` command to convert between MCF and JSON-LD formats.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ Data Commons powers [datacommons.org](https://datacommons.org), Google's open kn
 
 ## Getting Started
 
-This guide covers setting up a local Data Commons, defining schemas in JSON-LD, adding data via the command-line interface, and querying relationships.
-
-For deploying Data Commons to Google Cloud Platform (GCP) using Terraform, please refer to the detailed [GCP Infrastructure Guide](infra/dcp/README.md).
+This guide covers setting up Data Commons locally and in Google Cloud Platform (GCP), defining schemas in JSON-LD, adding data via the command-line interface, and querying relationships.
 
 ## Prerequisites
 
@@ -23,11 +21,11 @@ Before you begin, ensure you have the following installed:
 - A Google Cloud Platform (GCP) project with Cloud Spanner enabled
 - A Cloud Spanner instance and database (using Google Standard SQL) for storing the knowledge graph
 
-## Setting Up Data Commons
+## Setting Up Data Commons Locally
 
 This section will guide you through setting up Data Commons locally and defining your first custom schema and data.
 
-### 1. Install Data Commons Locally
+### 1. Install Data Commons
 
 To get started, you'll need to check out the Data Commons repository and set up your local environment.
 
@@ -340,7 +338,33 @@ You should see the:
 }
 ```
 
-### Schema Tools
+
+## Deploying Data Commons Platform In GCP
+
+Use the CLI to scaffold a Terraform deployment directory:
+
+```bash
+uv run datacommons infra init
+```
+
+The command will prompt for:
+- GCP project id
+- namespace
+- Data Commons API key
+
+It then creates a new folder with `main.tf`, `terraform.tfvars`, and a deployment `README.md`.
+
+From the generated folder:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+For the full infrastructure module and complete variable reference, see the detailed [GCP Infrastructure Guide](infra/dcp/README.md).
+
+## Schema Tools
 
 Use the `datacommons schema` command to convert between MCF and JSON-LD formats.
 

--- a/infra/dcp/README.md
+++ b/infra/dcp/README.md
@@ -21,8 +21,8 @@ Before you begin, ensure you have the following:
 
 If you want users to deploy from this module remotely (without cloning this repo), start from:
 
-*   [`examples/remote-module/main.tf`](/Users/dnoble/Projects/datacommons/datacommons/infra/dcp/examples/remote-module/main.tf)
-*   [`examples/remote-module/terraform.tfvars.example`](/Users/dnoble/Projects/datacommons/datacommons/infra/dcp/examples/remote-module/terraform.tfvars.example)
+*   [examples/remote-module/main.tf](examples/remote-module/main.tf)
+*   [examples/remote-module/terraform.tfvars.example](examples/remote-module/terraform.tfvars.example)
 
 This uses a Git module source in the form:
 

--- a/infra/dcp/README.md
+++ b/infra/dcp/README.md
@@ -17,6 +17,21 @@ Before you begin, ensure you have the following:
 
 ## Initial Setup
 
+### Remote Module Quick Start (Minimal Consumer Config)
+
+If you want users to deploy from this module remotely (without cloning this repo), start from:
+
+*   [`examples/remote-module/main.tf`](/Users/dnoble/Projects/datacommons/datacommons/infra/dcp/examples/remote-module/main.tf)
+*   [`examples/remote-module/terraform.tfvars.example`](/Users/dnoble/Projects/datacommons/datacommons/infra/dcp/examples/remote-module/terraform.tfvars.example)
+
+This uses a Git module source in the form:
+
+```hcl
+source = "git::https://github.com/<org>/<repo>.git//infra/dcp?ref=<tag-or-commit>"
+```
+
+Use a release tag or commit SHA (instead of `main`) for reproducible environments.
+
 ### 1. Configure Local Variables
 
 Copy the example variables file to create your local configuration:
@@ -46,6 +61,9 @@ You can control the deployment by setting values in `terraform.tfvars`. Here are
 
 ### Data Ingestion Config
 *   `dcp_deploy_data_ingestion_workflow` (bool): Set to `true` to deploy the Cloud Workflows orchestrator and ingestion runner service account.
+*   `dcp_ingestion_helper_image` (string): Docker image URL for the DCP ingestion helper service. Defaults to `gcr.io/datcom-ci/datacommons-ingestion-helper:latest`.
+*   `cdc_data_job_image` (string): Docker image URL for the CDC data ingestion job. Defaults to `gcr.io/datcom-ci/datacommons-data:stable`.
+*   `cdc_gcs_data_bucket_input_folder` (string): GCS data bucket input folder for CDC. Defaults to `input`.
 *   `create_ingestion_bucket` (bool): Controls whether Terraform automatically provisions a dedicated staging GCS bucket for uploading graph dataset (.mcf) files. Defaults to `true`.
 *   `external_ingestion_bucket_name` (string): If `create_ingestion_bucket` is false, specify an existing external GCS bucket name to attach permissions to.
 
@@ -68,6 +86,17 @@ Once configured, execute standard Terraform commands to provision resources:
     ```bash
     terraform apply
     ```
+
+## Outputs
+
+Upon successful apply, Terraform displays key endpoints and resource names:
+*   `dcp_service_url`: Cloud Run service URL for DCP.
+*   `cdc_service_url`: Cloud Run service URL for CDC.
+*   `workflow_name`: Name of the Cloud Workflows ingestion orchestrator.
+*   `dcp_ingestion_helper_uri`: URI of the DCP ingestion helper Cloud Run service.
+*   `cdc_data_job_name`: Name of the CDC Cloud Run data ingestion job.
+*   `dcp_spanner_instance_id`: ID of the provisioned or referenced Cloud Spanner instance.
+*   `dcp_spanner_database_id`: ID of the provisioned Cloud Spanner database.
 
 ## Running Data Ingestion Workflow
 

--- a/infra/dcp/examples/remote-module/main.tf
+++ b/infra/dcp/examples/remote-module/main.tf
@@ -11,8 +11,7 @@ terraform {
 
 module "datacommons_dcp" {
   # Pin this to a tag/commit for reproducible deployments.
-  # source = "git::https://github.com/datacommonsorg/datacommons.git//infra/dcp?ref=main"
-  source = "../infra/dcp"
+  source = "git::https://github.com/datacommonsorg/datacommons.git//infra/dcp?ref=main"
 
   project_id = var.project_id
   namespace  = var.namespace
@@ -44,6 +43,7 @@ variable "dc_api_key" {
   description = "Data Commons API key"
   type        = string
   default     = ""
+  sensitive = true
 }
 
 variable "dcp_create_spanner_instance" {

--- a/infra/dcp/examples/remote-module/main.tf
+++ b/infra/dcp/examples/remote-module/main.tf
@@ -1,0 +1,117 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.11.0"
+    }
+  }
+}
+
+module "datacommons_dcp" {
+  # Pin this to a tag/commit for reproducible deployments.
+  # source = "git::https://github.com/datacommonsorg/datacommons.git//infra/dcp?ref=main"
+  source = "../infra/dcp"
+
+  project_id = var.project_id
+  namespace  = var.namespace
+  cdc_dc_api_key = var.dc_api_key
+
+  enable_dcp = true
+  enable_cdc = true
+
+  dcp_create_spanner_instance        = var.dcp_create_spanner_instance
+  dcp_spanner_instance_id            = var.dcp_spanner_instance_id
+  dcp_spanner_database_id            = var.dcp_spanner_database_id
+  dcp_deploy_data_ingestion_workflow = var.dcp_deploy_data_ingestion_workflow
+  dcp_ingestion_helper_image         = var.dcp_ingestion_helper_image
+  cdc_gcs_data_bucket_input_folder   = var.gcs_data_bucket_input_folder
+  cdc_data_job_image                 = var.cdc_data_job_image
+}
+
+variable "project_id" {
+  description = "GCP project id"
+  type        = string
+}
+
+variable "namespace" {
+  description = "Prefix applied to provisioned resource names"
+  type        = string
+}
+
+variable "dc_api_key" {
+  description = "Data Commons API key"
+  type        = string
+  default     = ""
+}
+
+variable "dcp_create_spanner_instance" {
+  description = "Create a new Spanner instance for DCP"
+  type        = bool
+  default     = true
+}
+
+variable "dcp_spanner_instance_id" {
+  description = "Spanner instance id for DCP"
+  type        = string
+  default     = ""
+}
+
+variable "dcp_spanner_database_id" {
+  description = "Spanner database id for DCP"
+  type        = string
+  default     = "dcp-db"
+}
+
+variable "dcp_deploy_data_ingestion_workflow" {
+  description = "Deploy the complete end-to-end Data Commons Ingestion workflow stack"
+  type        = bool
+  default     = true
+}
+
+variable "dcp_ingestion_helper_image" {
+  description = "Docker image URL for the DCP ingestion helper service"
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
+}
+
+variable "gcs_data_bucket_input_folder" {
+  description = "GCS data bucket input folder for CDC"
+  type        = string
+  default     = "input"
+}
+
+variable "cdc_data_job_image" {
+  description = "Docker image URL for the CDC data ingestion job"
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-data:stable"
+}
+
+output "dcp_service_url" {
+  value = module.datacommons_dcp.dcp_service_url
+}
+
+output "dcp_spanner_instance_id" {
+  value = module.datacommons_dcp.dcp_spanner_instance_id
+}
+
+output "dcp_spanner_database_id" {
+  value = module.datacommons_dcp.dcp_spanner_database_id
+}
+
+output "dcp_ingestion_helper_uri" {
+  value = module.datacommons_dcp.dcp_ingestion_helper_uri
+}
+
+output "cdc_service_url" {
+  value = module.datacommons_dcp.cdc_service_url
+}
+
+output "cdc_data_job_name" {
+  value = module.datacommons_dcp.cdc_data_job_name
+}
+
+output "workflow_name" {
+  value = module.datacommons_dcp.workflow_name
+}

--- a/infra/dcp/examples/remote-module/terraform.tfvars.example
+++ b/infra/dcp/examples/remote-module/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Required variables
+project_id = "your-gcp-project-id"
+namespace  = "your-team"
+
+# Optional
+dcp_create_spanner_instance = false
+dcp_spanner_instance_id = "your-existing-spanner-instance-id"
+dcp_deploy_data_ingestion_workflow = true

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -83,6 +83,7 @@ locals {
     create_ingestion_bucket        = var.dcp_create_ingestion_bucket
     external_ingestion_bucket_name = var.dcp_external_ingestion_bucket_name
     ingestion_lock_timeout         = var.dcp_ingestion_lock_timeout
+    ingestion_helper_image         = var.dcp_ingestion_helper_image
   }
 
   stack_cdc = {

--- a/infra/dcp/modules/cdc_data_ingestion_job/main.tf
+++ b/infra/dcp/modules/cdc_data_ingestion_job/main.tf
@@ -55,6 +55,14 @@ resource "google_cloud_run_v2_job" "dc_data_job" {
           name  = "INPUT_DIR"
           value = "gs://${var.bucket_name}/${var.gcs_data_bucket_input_folder}"
         }
+
+        dynamic "env" {
+          for_each = var.use_spanner ? [1] : []
+          content {
+            name  = "DATA_RUN_MODE"
+            value = "dcpbridge"
+          }
+        }
       }
       dynamic "vpc_access" {
         for_each = var.vpc_connector_id != null && var.vpc_connector_id != "" ? [1] : []

--- a/infra/dcp/modules/cdc_data_ingestion_job/variables.tf
+++ b/infra/dcp/modules/cdc_data_ingestion_job/variables.tf
@@ -12,6 +12,7 @@ variable "bucket_name" { type = string }
 variable "gcs_data_bucket_input_folder" { type = string }
 variable "gcs_data_bucket_output_folder" { type = string }
 variable "run_db_init" { type = bool }
+variable "use_spanner" { type = bool }
 
 variable "env_vars" {
   type = list(object({

--- a/infra/dcp/modules/dcp_ingestion_helper/main.tf
+++ b/infra/dcp/modules/dcp_ingestion_helper/main.tf
@@ -10,7 +10,7 @@ resource "google_cloud_run_v2_service" "ingestion_helper" {
 
   template {
     containers {
-      image = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
+      image = var.ingestion_helper_image
 
       env {
         name  = "PROJECT_ID"

--- a/infra/dcp/modules/dcp_ingestion_helper/variables.tf
+++ b/infra/dcp/modules/dcp_ingestion_helper/variables.tf
@@ -33,3 +33,8 @@ variable "ingestion_bucket_name" {
 variable "service_account_email" {
   type = string
 }
+
+variable "ingestion_helper_image" {
+  type    = string
+  default = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
+}

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -194,8 +194,9 @@ module "dcp_ingestion_helper" {
   deletion_protection   = var.shared.deletion_protection
   spanner_instance_id   = module.spanner[0].spanner_instance_id
   spanner_database_id   = module.spanner[0].spanner_database_id
-  ingestion_bucket_name = module.storage.dcp_bucket_name
-  service_account_email = module.dcp_ingestion_dataflow[0].ingestion_runner_email
+  ingestion_bucket_name  = module.storage.dcp_bucket_name
+  service_account_email  = module.dcp_ingestion_dataflow[0].ingestion_runner_email
+  ingestion_helper_image = var.dcp.ingestion_helper_image
 }
 
 module "dcp_ingestion_workflow" {
@@ -287,8 +288,11 @@ module "cdc_data_ingestion_job" {
   gcs_data_bucket_input_folder  = var.cdc.gcs_data_bucket_input_folder
   gcs_data_bucket_output_folder = var.cdc.gcs_data_bucket_output_folder
   run_db_init                   = !local.cdc_use_spanner
+  use_spanner                   = local.cdc_use_spanner
   env_vars                      = local.cdc_cloud_run_shared_env_variables
   secret_env_vars               = local.cdc_cloud_run_shared_env_variable_secrets
+
+  depends_on = [module.cdc_iam]
 }
 
 module "cdc_services" {

--- a/infra/dcp/modules/stack/outputs.tf
+++ b/infra/dcp/modules/stack/outputs.tf
@@ -33,3 +33,13 @@ output "dcp_ingestion_orchestrator_name" {
   value       = var.toggles.enable_dcp && var.dcp.deploy_data_ingestion_workflow ? module.dcp_ingestion_workflow[0].ingestion_orchestrator_name : null
 }
 
+output "dcp_ingestion_helper_uri" {
+  description = "URI of the DCP ingestion helper Cloud Run service"
+  value       = var.toggles.enable_dcp && var.dcp.deploy_data_ingestion_workflow ? module.dcp_ingestion_helper[0].ingestion_helper_uri : null
+}
+
+output "cdc_data_job_name" {
+  description = "Name of the CDC Cloud Run data ingestion job"
+  value       = var.toggles.enable_cdc ? module.cdc_data_ingestion_job[0].job_name : null
+}
+

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -35,6 +35,7 @@ variable "dcp" {
     create_ingestion_bucket         = bool
     external_ingestion_bucket_name  = string
     ingestion_lock_timeout          = number
+    ingestion_helper_image          = string
   })
 }
 

--- a/infra/dcp/outputs.tf
+++ b/infra/dcp/outputs.tf
@@ -33,3 +33,13 @@ output "workflow_name" {
   value       = module.stack.dcp_ingestion_orchestrator_name
 }
 
+output "dcp_ingestion_helper_uri" {
+  description = "URI of the DCP ingestion helper Cloud Run service"
+  value       = module.stack.dcp_ingestion_helper_uri
+}
+
+output "cdc_data_job_name" {
+  description = "Name of the CDC Cloud Run data ingestion job"
+  value       = module.stack.cdc_data_job_name
+}
+

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -381,3 +381,9 @@ variable "dcp_ingestion_lock_timeout" {
   default     = 82800
 }
 
+variable "dcp_ingestion_helper_image" {
+  description = "Docker image URL for the DCP ingestion helper service"
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
+}
+


### PR DESCRIPTION
## Description
Various terraform fixes

### Changes
* Adde example terraform modules to demonstrate fetching core terraform stack via git
* Exposed `dcp_deploy_service`, `dcp_ingestion_helper_image`, `cdc_data_job_image`, and `cdc_gcs_data_bucket_input_folder` across the root module, submodules, and example templates to allow overrides (e.g., custom container tags and input paths).
* Added new outputs: `dcp_spanner_instance_id`, `dcp_spanner_database_id`, `workflow_name`, `dcp_ingestion_helper_uri`, and `cdc_data_job_name`.
* Injects `DATA_RUN_MODE = "dcpbridge"` into the CDC data ingestion job container spec when Spanner is enabled.
* Added an explicit `depends_on = [module.cdc_iam]` to `cdc_data_ingestion_job` to fix IAM propagation race conditions during initial Cloud Run Job provisioning.