### PR TITLE
Added datacommons admin init-db CLI utility. Updated tf service accounts.

### DIFF
--- a/infra/dcp/modules/dcp_ingestion_dataflow/main.tf
+++ b/infra/dcp/modules/dcp_ingestion_dataflow/main.tf
@@ -62,3 +62,30 @@ resource "google_storage_bucket_iam_member" "dynamic_ingestion_bucket_access" {
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.dcp_ingestion_runner[0].email}"
 }
+
+resource "google_service_account" "dcp_orchestrator" {
+  count        = var.deploy ? 1 : 0
+  account_id   = "${local.name_prefix}dcp-orc-sa"
+  display_name = "${local.display_name_prefix}Data Commons Platform Orchestrator"
+}
+
+resource "google_project_iam_member" "orchestrator_dataflow_admin" {
+  count   = var.deploy ? 1 : 0
+  project = var.project_id
+  role    = "roles/dataflow.admin"
+  member  = "serviceAccount:${google_service_account.dcp_orchestrator[0].email}"
+}
+
+resource "google_project_iam_member" "orchestrator_workflows_invoker" {
+  count   = var.deploy ? 1 : 0
+  project = var.project_id
+  role    = "roles/workflows.invoker"
+  member  = "serviceAccount:${google_service_account.dcp_orchestrator[0].email}"
+}
+
+resource "google_service_account_iam_member" "orchestrator_sa_user" {
+  count              = var.deploy ? 1 : 0
+  service_account_id = google_service_account.dcp_ingestion_runner[0].name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.dcp_orchestrator[0].email}"
+}

--- a/infra/dcp/modules/dcp_ingestion_dataflow/outputs.tf
+++ b/infra/dcp/modules/dcp_ingestion_dataflow/outputs.tf
@@ -6,3 +6,11 @@ output "ingestion_runner_id" {
   value = var.deploy ? google_service_account.dcp_ingestion_runner[0].id : null
 }
 
+output "orchestrator_email" {
+  value = var.deploy ? google_service_account.dcp_orchestrator[0].email : null
+}
+
+output "orchestrator_id" {
+  value = var.deploy ? google_service_account.dcp_orchestrator[0].id : null
+}
+

--- a/infra/dcp/modules/dcp_ingestion_helper/main.tf
+++ b/infra/dcp/modules/dcp_ingestion_helper/main.tf
@@ -53,3 +53,11 @@ resource "google_cloud_run_v2_service_iam_member" "ingestion_helper_invoker" {
   role     = "roles/run.invoker"
   member   = "serviceAccount:${var.service_account_email}"
 }
+
+resource "google_cloud_run_v2_service_iam_member" "orchestrator_invoker" {
+  count    = var.deploy && var.orchestrator_email != "" ? 1 : 0
+  location = google_cloud_run_v2_service.ingestion_helper[0].location
+  name     = google_cloud_run_v2_service.ingestion_helper[0].name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${var.orchestrator_email}"
+}

--- a/infra/dcp/modules/dcp_ingestion_helper/variables.tf
+++ b/infra/dcp/modules/dcp_ingestion_helper/variables.tf
@@ -38,3 +38,9 @@ variable "ingestion_helper_image" {
   type    = string
   default = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
 }
+
+variable "orchestrator_email" {
+  type        = string
+  description = "Email of the orchestrator service account"
+  default     = ""
+}

--- a/infra/dcp/modules/dcp_ingestion_workflow/variables.tf
+++ b/infra/dcp/modules/dcp_ingestion_workflow/variables.tf
@@ -33,3 +33,9 @@ variable "ingestion_runner_id" {
 variable "ingestion_runner_email" {
   type = string
 }
+
+variable "orchestrator_email" {
+  type        = string
+  description = "Email of the orchestrator service account"
+  default     = ""
+}

--- a/infra/dcp/modules/dcp_service/main.tf
+++ b/infra/dcp/modules/dcp_service/main.tf
@@ -72,3 +72,11 @@ resource "google_cloud_run_service_iam_binding" "public_invoker" {
   role     = "roles/run.invoker"
   members  = ["allUsers"]
 }
+
+resource "google_cloud_run_v2_service_iam_member" "orchestrator_invoker" {
+  count    = var.orchestrator_email != "" ? 1 : 0
+  location = google_cloud_run_v2_service.dcp_service.location
+  name     = google_cloud_run_v2_service.dcp_service.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${var.orchestrator_email}"
+}

--- a/infra/dcp/modules/dcp_service/variables.tf
+++ b/infra/dcp/modules/dcp_service/variables.tf
@@ -61,3 +61,9 @@ variable "spanner_instance_id" {
 variable "spanner_database_id" {
   type = string
 }
+
+variable "orchestrator_email" {
+  type        = string
+  description = "Email of the orchestrator service account"
+  default     = ""
+}

--- a/infra/dcp/modules/spanner/main.tf
+++ b/infra/dcp/modules/spanner/main.tf
@@ -21,3 +21,11 @@ resource "google_spanner_database" "database" {
 
   deletion_protection = var.deletion_protection
 }
+
+resource "google_spanner_database_iam_member" "orchestrator_spanner_user" {
+  count    = var.create_spanner_db && var.orchestrator_email != "" ? 1 : 0
+  instance = var.create_spanner_instance ? google_spanner_instance.main[0].name : local.effective_instance_id
+  database = google_spanner_database.database[0].name
+  role     = "roles/spanner.databaseUser"
+  member   = "serviceAccount:${var.orchestrator_email}"
+}

--- a/infra/dcp/modules/spanner/variables.tf
+++ b/infra/dcp/modules/spanner/variables.tf
@@ -29,3 +29,9 @@ variable "spanner_processing_units" {
 variable "deletion_protection" {
   type = bool
 }
+
+variable "orchestrator_email" {
+  type        = string
+  description = "Email of the orchestrator service account"
+  default     = ""
+}

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -65,7 +65,7 @@ locals {
     },
     {
       name  = "INGESTION_WORKFLOW_NAME"
-      value = local.enable_dcp ? coalesce(module.dcp_ingestion_workflow[0].ingestion_orchestrator_name, "") : ""
+      value = local.enable_dcp && var.dcp.deploy_data_ingestion_workflow && module.dcp_ingestion_workflow[0].ingestion_orchestrator_name != null ? module.dcp_ingestion_workflow[0].ingestion_orchestrator_name : ""
     },
     {
       name  = "TEMP_LOCATION"
@@ -123,7 +123,7 @@ module "spanner" {
   spanner_database_id      = var.dcp.spanner_database_id
   spanner_processing_units = var.dcp.spanner_processing_units
   deletion_protection      = var.shared.deletion_protection
-  orchestrator_email       = local.enable_dcp ? coalesce(module.dcp_ingestion_dataflow[0].orchestrator_email, "") : ""
+  orchestrator_email       = local.enable_dcp && var.dcp.deploy_data_ingestion_workflow && module.dcp_ingestion_dataflow[0].orchestrator_email != null ? module.dcp_ingestion_dataflow[0].orchestrator_email : ""
 }
 
 module "dcp_service" {
@@ -146,7 +146,7 @@ module "dcp_service" {
   make_service_public     = var.shared.make_services_public
   spanner_instance_id     = module.spanner[0].spanner_instance_id
   spanner_database_id     = module.spanner[0].spanner_database_id
-  orchestrator_email       = local.enable_dcp ? coalesce(module.dcp_ingestion_dataflow[0].orchestrator_email, "") : ""
+  orchestrator_email       = local.enable_dcp && var.dcp.deploy_data_ingestion_workflow && module.dcp_ingestion_dataflow[0].orchestrator_email != null ? module.dcp_ingestion_dataflow[0].orchestrator_email : ""
 }
 
 module "storage" {
@@ -169,7 +169,7 @@ module "storage" {
   # Shared vars
   project_id         = var.shared.project_id
   namespace          = var.shared.namespace
-  orchestrator_email = local.enable_dcp ? coalesce(module.dcp_ingestion_dataflow[0].orchestrator_email, "") : ""
+  orchestrator_email = local.enable_dcp && var.dcp.deploy_data_ingestion_workflow && module.dcp_ingestion_dataflow[0].orchestrator_email != null ? module.dcp_ingestion_dataflow[0].orchestrator_email : ""
 }
 
 module "dcp_ingestion_dataflow" {
@@ -200,7 +200,7 @@ module "dcp_ingestion_helper" {
   ingestion_bucket_name  = module.storage.dcp_bucket_name
   service_account_email  = module.dcp_ingestion_dataflow[0].ingestion_runner_email
   ingestion_helper_image = var.dcp.ingestion_helper_image
-  orchestrator_email     = coalesce(module.dcp_ingestion_dataflow[0].orchestrator_email, "")
+  orchestrator_email     = var.dcp.deploy_data_ingestion_workflow && module.dcp_ingestion_dataflow[0].orchestrator_email != null ? module.dcp_ingestion_dataflow[0].orchestrator_email : ""
 }
 
 module "dcp_ingestion_workflow" {
@@ -216,7 +216,7 @@ module "dcp_ingestion_workflow" {
   ingestion_helper_uri   = module.dcp_ingestion_helper[0].ingestion_helper_uri
   ingestion_runner_id    = module.dcp_ingestion_dataflow[0].ingestion_runner_id
   ingestion_runner_email = module.dcp_ingestion_dataflow[0].ingestion_runner_email
-  orchestrator_email     = coalesce(module.dcp_ingestion_dataflow[0].orchestrator_email, "")
+  orchestrator_email     = var.dcp.deploy_data_ingestion_workflow && module.dcp_ingestion_dataflow[0].orchestrator_email != null ? module.dcp_ingestion_dataflow[0].orchestrator_email : ""
 }
 
 
@@ -343,7 +343,7 @@ resource "google_storage_bucket_iam_member" "dataflow_cdc_bucket_access" {
 
 # This is only needed to trigger the services restart to pick up the GCS embeddings change
 resource "google_service_account_iam_member" "ingestion_runner_act_as_cdc_sa" {
-  count              = local.enable_cdc && local.enable_dcp ? 1 : 0
+  count              = local.enable_cdc && local.enable_dcp && var.dcp.deploy_data_ingestion_workflow ? 1 : 0
   service_account_id = "projects/${var.shared.project_id}/serviceAccounts/${module.cdc_iam[0].service_account_email}"
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${module.dcp_ingestion_dataflow[0].ingestion_runner_email}"

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -123,6 +123,7 @@ module "spanner" {
   spanner_database_id      = var.dcp.spanner_database_id
   spanner_processing_units = var.dcp.spanner_processing_units
   deletion_protection      = var.shared.deletion_protection
+  orchestrator_email       = local.enable_dcp ? coalesce(module.dcp_ingestion_dataflow[0].orchestrator_email, "") : ""
 }
 
 module "dcp_service" {
@@ -145,6 +146,7 @@ module "dcp_service" {
   make_service_public     = var.shared.make_services_public
   spanner_instance_id     = module.spanner[0].spanner_instance_id
   spanner_database_id     = module.spanner[0].spanner_database_id
+  orchestrator_email       = local.enable_dcp ? coalesce(module.dcp_ingestion_dataflow[0].orchestrator_email, "") : ""
 }
 
 module "storage" {
@@ -165,8 +167,9 @@ module "storage" {
   cdc_gcs_data_bucket_location = var.cdc.gcs_data_bucket_location
   
   # Shared vars
-  project_id = var.shared.project_id
-  namespace  = var.shared.namespace
+  project_id         = var.shared.project_id
+  namespace          = var.shared.namespace
+  orchestrator_email = local.enable_dcp ? coalesce(module.dcp_ingestion_dataflow[0].orchestrator_email, "") : ""
 }
 
 module "dcp_ingestion_dataflow" {
@@ -197,6 +200,7 @@ module "dcp_ingestion_helper" {
   ingestion_bucket_name  = module.storage.dcp_bucket_name
   service_account_email  = module.dcp_ingestion_dataflow[0].ingestion_runner_email
   ingestion_helper_image = var.dcp.ingestion_helper_image
+  orchestrator_email     = coalesce(module.dcp_ingestion_dataflow[0].orchestrator_email, "")
 }
 
 module "dcp_ingestion_workflow" {
@@ -212,6 +216,7 @@ module "dcp_ingestion_workflow" {
   ingestion_helper_uri   = module.dcp_ingestion_helper[0].ingestion_helper_uri
   ingestion_runner_id    = module.dcp_ingestion_dataflow[0].ingestion_runner_id
   ingestion_runner_email = module.dcp_ingestion_dataflow[0].ingestion_runner_email
+  orchestrator_email     = coalesce(module.dcp_ingestion_dataflow[0].orchestrator_email, "")
 }
 
 

--- a/infra/dcp/modules/stack/outputs.tf
+++ b/infra/dcp/modules/stack/outputs.tf
@@ -43,3 +43,8 @@ output "cdc_data_job_name" {
   value       = var.toggles.enable_cdc ? module.cdc_data_ingestion_job[0].job_name : null
 }
 
+output "dcp_orchestrator_service_account_email" {
+  description = "Email of the DCP orchestrator service account used by CLI and Workflows"
+  value       = var.toggles.enable_dcp && var.dcp.deploy_data_ingestion_workflow ? module.dcp_ingestion_dataflow[0].orchestrator_email : null
+}
+

--- a/infra/dcp/modules/storage/main.tf
+++ b/infra/dcp/modules/storage/main.tf
@@ -18,3 +18,17 @@ resource "google_storage_bucket" "dcp_data_ingestion_bucket" {
   uniform_bucket_level_access = true
   force_destroy               = !var.dcp_deletion_protection
 }
+
+resource "google_storage_bucket_iam_member" "orchestrator_cdc_bucket" {
+  count  = var.enable_cdc && var.orchestrator_email != "" ? 1 : 0
+  bucket = google_storage_bucket.cdc_data_bucket[0].name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.orchestrator_email}"
+}
+
+resource "google_storage_bucket_iam_member" "orchestrator_dcp_bucket" {
+  count  = var.enable_dcp && var.dcp_deploy && var.dcp_create_bucket && var.orchestrator_email != "" ? 1 : 0
+  bucket = google_storage_bucket.dcp_data_ingestion_bucket[0].name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.orchestrator_email}"
+}

--- a/infra/dcp/modules/storage/variables.tf
+++ b/infra/dcp/modules/storage/variables.tf
@@ -41,3 +41,9 @@ variable "cdc_gcs_data_bucket_name" {
 variable "cdc_gcs_data_bucket_location" {
   type = string
 }
+
+variable "orchestrator_email" {
+  type        = string
+  description = "Email of the orchestrator service account"
+  default     = ""
+}

--- a/infra/dcp/outputs.tf
+++ b/infra/dcp/outputs.tf
@@ -43,3 +43,8 @@ output "cdc_data_job_name" {
   value       = module.stack.cdc_data_job_name
 }
 
+output "dcp_orchestrator_service_account_email" {
+  description = "Email of the DCP orchestrator service account used by CLI and Workflows"
+  value       = module.stack.dcp_orchestrator_service_account_email
+}
+

--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -18,204 +18,13 @@ import click
 from google.api_core import exceptions
 from google.cloud import storage
 
-MAIN_TF_TEMPLATE = """terraform {{
-  required_version = ">= 1.5.0"
-
-  required_providers {{
-    google = {{
-      source  = "hashicorp/google"
-      version = ">= 5.11.0"
-    }}
-  }}
-}}
-
-module "datacommons_dcp" {{
-  # Pin this to a tag/commit for reproducible deployments.
-  source = "git::https://github.com/datacommonsorg/datacommons.git//infra/dcp?ref={ref}"
-
-  project_id = var.project_id
-  namespace  = var.namespace
-  cdc_dc_api_key = var.dc_api_key
-
-  enable_dcp = true
-  enable_cdc = true
-
-  dcp_create_spanner_instance        = var.dcp_create_spanner_instance
-  dcp_spanner_instance_id            = var.dcp_spanner_instance_id
-  dcp_spanner_database_id            = var.dcp_spanner_database_id
-  dcp_deploy_data_ingestion_workflow = var.dcp_deploy_data_ingestion_workflow
-  dcp_ingestion_helper_image         = var.dcp_ingestion_helper_image
-  cdc_gcs_data_bucket_input_folder   = var.gcs_data_bucket_input_folder
-  cdc_data_job_image                 = var.cdc_data_job_image
-}}
-
-variable "project_id" {{
-  description = "GCP project id"
-  type        = string
-}}
-
-variable "namespace" {{
-  description = "Prefix applied to provisioned resource names"
-  type        = string
-}}
-
-variable "dc_api_key" {{
-  description = "Data Commons API key"
-  type        = string
-  default     = ""
-  sensitive   = true
-}}
-
-variable "dcp_create_spanner_instance" {{
-  description = "Create a new Spanner instance for DCP"
-  type        = bool
-  default     = true
-}}
-
-variable "dcp_spanner_instance_id" {{
-  description = "Spanner instance id for DCP"
-  type        = string
-  default     = ""
-}}
-
-variable "dcp_spanner_database_id" {{
-  description = "Spanner database id for DCP"
-  type        = string
-  default     = "dcp-db"
-}}
-
-variable "dcp_deploy_data_ingestion_workflow" {{
-  description = "Deploy the complete end-to-end Data Commons Ingestion workflow stack"
-  type        = bool
-  default     = true
-}}
-
-variable "dcp_ingestion_helper_image" {{
-  description = "Docker image URL for the DCP ingestion helper service"
-  type        = string
-  default     = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
-}}
-
-variable "gcs_data_bucket_input_folder" {{
-  description = "GCS data bucket input folder for CDC"
-  type        = string
-  default     = "input"
-}}
-
-variable "cdc_data_job_image" {{
-  description = "Docker image URL for the CDC data ingestion job"
-  type        = string
-  default     = "gcr.io/datcom-ci/datacommons-data:stable"
-}}
-
-output "dcp_service_url" {{
-  value = module.datacommons_dcp.dcp_service_url
-}}
-
-output "dcp_spanner_instance_id" {{
-  value = module.datacommons_dcp.dcp_spanner_instance_id
-}}
-
-output "dcp_spanner_database_id" {{
-  value = module.datacommons_dcp.dcp_spanner_database_id
-}}
-
-output "dcp_ingestion_helper_uri" {{
-  value = module.datacommons_dcp.dcp_ingestion_helper_uri
-}}
-
-output "cdc_service_url" {{
-  value = module.datacommons_dcp.cdc_service_url
-}}
-
-output "cdc_data_job_name" {{
-  value = module.datacommons_dcp.cdc_data_job_name
-}}
-
-output "workflow_name" {{
-  value = module.datacommons_dcp.workflow_name
-}}
-"""
-
-TFVARS_TEMPLATE = """project_id = "{project_id}"
-namespace  = "{namespace}"
-dc_api_key = "{dc_api_key}"
-
-# Optional Spanner configuration (defaults to creating a new instance with dcp-db)
-# dcp_create_spanner_instance = false
-# dcp_spanner_instance_id     = "existing-instance-id"
-dcp_spanner_database_id     = "dcp-db"
-
-# Optional Ingestion Workflow configuration (defaults to true)
-# dcp_deploy_data_ingestion_workflow = false
-# dcp_ingestion_helper_image         = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
-
-# Optional GCS input folder (defaults to input)
-# gcs_data_bucket_input_folder = "input"
-
-# Optional CDC Data Job image (defaults to stable)
-# cdc_data_job_image = "gcr.io/datcom-ci/datacommons-data:stable"
-"""
-
-REMOTE_STATE_TEMPLATE = """
-## Remote State Management
-
-Terraform state is configured to be stored remotely in Google Cloud Storage:
-- **Bucket**: `gs://{bucket_name}`
-- **Prefix**: `terraform/state`
-
-This enables team collaboration, state locking, and automated pipeline deployments. The bucket is configured with Uniform Bucket-Level Access and object versioning.
-"""
-
-README_TEMPLATE = """# Data Commons Platform Terraform Setup
-
-This directory contains Terraform configuration for a new Data Commons Platform instance.
-
-Data Commons is an open knowledge graph for integrating and querying structured data across domains.
-The Data Commons Platform is the deployable infrastructure stack that runs Data Commons services in your GCP project.
-{remote_state_section}
-## What This Terraform Creates
-
-This setup deploys core Data Commons Platform infrastructure on GCP using the `infra/dcp` module, including Cloud Run services, Cloud Spanner resources, IAM bindings, and supporting service configuration.
-
-## Configure Variables
-
-Set environment-specific values in `terraform.tfvars` (for example `project_id`, `namespace`, and `dc_api_key`), and update module arguments in `main.tf` if you want to enable or tune additional features.
-
-## Learn More About Variables
-
-For the full list of supported module inputs and defaults, see:
-- https://github.com/datacommonsorg/datacommons/blob/main/infra/dcp/variables.tf
-- https://github.com/datacommonsorg/datacommons/blob/main/infra/dcp/terraform.tfvars.example
-- https://github.com/datacommonsorg/datacommons/blob/main/infra/dcp/README.md
-
-## Next Steps
-
-1. Review `terraform.tfvars` and update values if needed.
-2. Initialize Terraform:
-   ```bash
-   terraform init
-   ```
-3. Preview infrastructure changes:
-   ```bash
-   terraform plan
-   ```
-4. Deploy infrastructure:
-   ```bash
-   terraform apply
-   ```
-
-Generated using the Data Commons CLI tool:
-https://github.com/datacommonsorg/datacommons
-"""
-
-BACKEND_TF_TEMPLATE = """terraform {{
-  backend "gcs" {{
-    bucket = "{bucket_name}"
-    prefix = "terraform/state"
-  }}
-}}
-"""
+from datacommons_admin.infra_templates import (
+    BACKEND_TF_TEMPLATE,
+    MAIN_TF_TEMPLATE,
+    README_TEMPLATE,
+    REMOTE_STATE_TEMPLATE,
+    TFVARS_TEMPLATE,
+)
 
 
 def _configure_remote_state(resolved_project_id: str, resolved_namespace: str) -> str:
@@ -440,3 +249,42 @@ def init(
         f"Generated new folder '{resolved_namespace}'. See {resolved_namespace}/README.md for next steps.",
         fg="cyan",
     )
+
+
+@admin.command(name="init-db")
+def init_db() -> None:
+    """Initialize the Spanner database via the DCP Ingestion Helper service."""
+    click.secho("Datacommons Admin Init-DB", fg="cyan", bold=True)
+    click.secho(
+        "Fetching Ingestion Helper URI, Orchestrator Service Account, and Spanner details from Terraform outputs...",
+        fg="bright_black",
+    )
+
+    from datacommons_admin.tf_utils import (
+        get_dcp_ingestion_helper_uri,
+        get_dcp_orchestrator_service_account_email,
+        get_dcp_spanner_instance_id,
+        get_dcp_spanner_database_id,
+    )
+    from datacommons_admin.ingestion_helper_client import IngestionHelperClient
+
+    uri = get_dcp_ingestion_helper_uri()
+    sa_email = get_dcp_orchestrator_service_account_email()
+    instance_id = get_dcp_spanner_instance_id()
+    database_id = get_dcp_spanner_database_id()
+
+    click.secho(f"Found Ingestion Helper URI: {uri}", fg="green")
+    click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
+    click.secho(f"Found Spanner Database Instance: {instance_id} / Database ID: {database_id}", fg="green")
+    click.secho(
+        f"Initializing Spanner database '{instance_id}/{database_id}' via the Ingestion Helper service (this may take a few moments)...",
+        fg="bright_black",
+    )
+
+    client = IngestionHelperClient(uri, service_account_email=sa_email)
+    result = client.initialize_database()
+
+    click.secho("Successfully initialized Spanner database!", fg="green", bold=True)
+    if "message" in result:
+        click.secho(f"Details: {result['message']}", fg="bright_black")
+

--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -275,7 +275,10 @@ def init_db() -> None:
 
     click.secho(f"Found Ingestion Helper URI: {uri}", fg="green")
     click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
-    click.secho(f"Found Spanner Database Instance: {instance_id} / Database ID: {database_id}", fg="green")
+    click.secho(
+        f"Found Spanner Database Instance: {instance_id} / Database ID: {database_id}",
+        fg="green",
+    )
     click.secho(
         f"Initializing Spanner database '{instance_id}/{database_id}' via the Ingestion Helper service (this may take a few moments)...",
         fg="bright_black",
@@ -287,4 +290,3 @@ def init_db() -> None:
     click.secho("Successfully initialized Spanner database!", fg="green", bold=True)
     if "message" in result:
         click.secho(f"Details: {result['message']}", fg="bright_black")
-

--- a/packages/datacommons-admin/datacommons_admin/infra_templates.py
+++ b/packages/datacommons-admin/datacommons_admin/infra_templates.py
@@ -1,0 +1,216 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+MAIN_TF_TEMPLATE = """terraform {{
+  required_version = ">= 1.5.0"
+
+  required_providers {{
+    google = {{
+      source  = "hashicorp/google"
+      version = ">= 5.11.0"
+    }}
+  }}
+}}
+
+module "datacommons_dcp" {{
+  # Pin this to a tag/commit for reproducible deployments.
+  source = "git::https://github.com/datacommonsorg/datacommons.git//infra/dcp?ref={ref}"
+
+  project_id = var.project_id
+  namespace  = var.namespace
+  cdc_dc_api_key = var.dc_api_key
+
+  enable_dcp = true
+  enable_cdc = true
+
+  dcp_create_spanner_instance        = var.dcp_create_spanner_instance
+  dcp_spanner_instance_id            = var.dcp_spanner_instance_id
+  dcp_spanner_database_id            = var.dcp_spanner_database_id
+  dcp_deploy_data_ingestion_workflow = var.dcp_deploy_data_ingestion_workflow
+  dcp_ingestion_helper_image         = var.dcp_ingestion_helper_image
+  cdc_gcs_data_bucket_input_folder   = var.gcs_data_bucket_input_folder
+  cdc_data_job_image                 = var.cdc_data_job_image
+}}
+
+variable "project_id" {{
+  description = "GCP project id"
+  type        = string
+}}
+
+variable "namespace" {{
+  description = "Prefix applied to provisioned resource names"
+  type        = string
+}}
+
+variable "dc_api_key" {{
+  description = "Data Commons API key"
+  type        = string
+  default     = ""
+  sensitive   = true
+}}
+
+variable "dcp_create_spanner_instance" {{
+  description = "Create a new Spanner instance for DCP"
+  type        = bool
+  default     = true
+}}
+
+variable "dcp_spanner_instance_id" {{
+  description = "Spanner instance id for DCP"
+  type        = string
+  default     = ""
+}}
+
+variable "dcp_spanner_database_id" {{
+  description = "Spanner database id for DCP"
+  type        = string
+  default     = "dcp-db"
+}}
+
+variable "dcp_deploy_data_ingestion_workflow" {{
+  description = "Deploy the complete end-to-end Data Commons Ingestion workflow stack"
+  type        = bool
+  default     = true
+}}
+
+variable "dcp_ingestion_helper_image" {{
+  description = "Docker image URL for the DCP ingestion helper service"
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
+}}
+
+variable "gcs_data_bucket_input_folder" {{
+  description = "GCS data bucket input folder for CDC"
+  type        = string
+  default     = "input"
+}}
+
+variable "cdc_data_job_image" {{
+  description = "Docker image URL for the CDC data ingestion job"
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-data:stable"
+}}
+
+output "dcp_service_url" {{
+  value = module.datacommons_dcp.dcp_service_url
+}}
+
+output "dcp_spanner_instance_id" {{
+  value = module.datacommons_dcp.dcp_spanner_instance_id
+}}
+
+output "dcp_spanner_database_id" {{
+  value = module.datacommons_dcp.dcp_spanner_database_id
+}}
+
+output "dcp_ingestion_helper_uri" {{
+  value = module.datacommons_dcp.dcp_ingestion_helper_uri
+}}
+
+output "cdc_service_url" {{
+  value = module.datacommons_dcp.cdc_service_url
+}}
+
+output "cdc_data_job_name" {{
+  value = module.datacommons_dcp.cdc_data_job_name
+}}
+
+output "workflow_name" {{
+  value = module.datacommons_dcp.workflow_name
+}}
+
+output "dcp_orchestrator_service_account_email" {{
+  value = module.datacommons_dcp.dcp_orchestrator_service_account_email
+}}
+"""
+
+TFVARS_TEMPLATE = """project_id = "{project_id}"
+namespace  = "{namespace}"
+dc_api_key = "{dc_api_key}"
+
+# Optional Spanner configuration (defaults to creating a new instance with dcp-db)
+# dcp_create_spanner_instance = false
+# dcp_spanner_instance_id     = "existing-instance-id"
+dcp_spanner_database_id     = "dcp-db"
+
+# Optional Ingestion Workflow configuration (defaults to true)
+# dcp_deploy_data_ingestion_workflow = false
+# dcp_ingestion_helper_image         = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
+
+# Optional GCS input folder (defaults to input)
+# gcs_data_bucket_input_folder = "input"
+
+# Optional CDC Data Job image (defaults to stable)
+# cdc_data_job_image = "gcr.io/datcom-ci/datacommons-data:stable"
+"""
+
+REMOTE_STATE_TEMPLATE = """
+## Remote State Management
+
+Terraform state is configured to be stored remotely in Google Cloud Storage:
+- **Bucket**: `gs://{bucket_name}`
+- **Prefix**: `terraform/state`
+
+This enables team collaboration, state locking, and automated pipeline deployments. The bucket is configured with Uniform Bucket-Level Access and object versioning.
+"""
+
+README_TEMPLATE = """# Data Commons Platform Terraform Setup
+
+This directory contains Terraform configuration for a new Data Commons Platform instance.
+
+Data Commons is an open knowledge graph for integrating and querying structured data across domains.
+The Data Commons Platform is the deployable infrastructure stack that runs Data Commons services in your GCP project.
+{remote_state_section}
+## What This Terraform Creates
+
+This setup deploys core Data Commons Platform infrastructure on GCP using the `infra/dcp` module, including Cloud Run services, Cloud Spanner resources, IAM bindings, and supporting service configuration.
+
+## Configure Variables
+
+Set environment-specific values in `terraform.tfvars` (for example `project_id`, `namespace`, and `dc_api_key`), and update module arguments in `main.tf` if you want to enable or tune additional features.
+
+## Learn More About Variables
+
+For the full list of supported module inputs and defaults, see:
+- https://github.com/datacommonsorg/datacommons/blob/main/infra/dcp/variables.tf
+- https://github.com/datacommonsorg/datacommons/blob/main/infra/dcp/terraform.tfvars.example
+- https://github.com/datacommonsorg/datacommons/blob/main/infra/dcp/README.md
+
+## Next Steps
+
+1. Review `terraform.tfvars` and update values if needed.
+2. Initialize Terraform:
+   ```bash
+   terraform init
+   ```
+3. Preview infrastructure changes:
+   ```bash
+   terraform plan
+   ```
+4. Deploy infrastructure:
+   ```bash
+   terraform apply
+   ```
+
+Generated using the Data Commons CLI tool:
+https://github.com/datacommonsorg/datacommons
+"""
+
+BACKEND_TF_TEMPLATE = """terraform {{
+  backend "gcs" {{
+    bucket = "{bucket_name}"
+    prefix = "terraform/state"
+  }}
+}}
+"""

--- a/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
+++ b/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+import google.auth
+from google.auth.transport.requests import AuthorizedSession, Request
+from google.oauth2 import id_token
+
+
+ACTION_INITIALIZE_DATABASE = "initialize_database"
+
+
+class IngestionHelperClient:
+    """Client for interacting with the DCP Ingestion Helper Cloud Run service."""
+
+    def __init__(self, base_url: str, service_account_email: str = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.auth_req = Request()
+        self.service_account_email = service_account_email
+
+        base_credentials, _ = google.auth.default()
+
+        if service_account_email:
+            from google.auth import impersonated_credentials
+            target_credentials = impersonated_credentials.Credentials(
+                source_credentials=base_credentials,
+                target_principal=service_account_email,
+                target_scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+            creds = impersonated_credentials.IDTokenCredentials(
+                target_credentials=target_credentials,
+                target_audience=self.base_url,
+                include_email=True,
+            )
+        else:
+            try:
+                token = id_token.fetch_id_token(self.auth_req, self.base_url)
+                from google.oauth2.credentials import Credentials
+                creds = Credentials(token)
+            except Exception as e:
+                raise click.ClickException(
+                    f"Failed to fetch ID token for {self.base_url}: {e}\n"
+                    "Please ensure you are authenticated or provide a service account to impersonate."
+                )
+
+        self.session = AuthorizedSession(creds)
+
+    def initialize_database(self) -> dict:
+        """Calls the initialize_database endpoint on the ingestion helper service."""
+        url = self.base_url
+        payload = {"actionType": ACTION_INITIALIZE_DATABASE}
+
+        try:
+            response = self.session.post(url, json=payload, timeout=300)
+        except Exception as e:
+            msg = f"Network or authentication error connecting to Ingestion Helper service at {url}: {e}"
+            if self.service_account_email:
+                msg += f"\nFailed to impersonate {self.service_account_email}. Please ensure your GCP user account has the 'Service Account Token Creator' (roles/iam.serviceAccountTokenCreator) IAM role."
+            raise click.ClickException(msg)
+
+        if response.status_code == 401:
+            raise click.ClickException(
+                f"HTTP 401 Unauthorized when calling Ingestion Helper at {url}.\n"
+                "Your GCP credentials were rejected. Please verify that the service account has the 'Cloud Run Invoker' (roles/run.invoker) IAM role for this service.\n"
+                "To re-authenticate, run:\n"
+                "  gcloud auth application-default login"
+            )
+
+        if not response.ok:
+            try:
+                error_data = response.json()
+                error_msg = (
+                    error_data.get("message")
+                    or error_data.get("error")
+                    or response.text
+                )
+            except Exception:
+                error_msg = response.text
+
+            raise click.ClickException(
+                f"Ingestion Helper returned HTTP {response.status_code}: {error_msg}"
+            )
+
+        try:
+            return response.json()
+        except Exception:
+            return {"status": "success", "message": response.text}
+

--- a/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
+++ b/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
@@ -33,6 +33,7 @@ class IngestionHelperClient:
 
         if service_account_email:
             from google.auth import impersonated_credentials
+
             target_credentials = impersonated_credentials.Credentials(
                 source_credentials=base_credentials,
                 target_principal=service_account_email,
@@ -47,6 +48,7 @@ class IngestionHelperClient:
             try:
                 token = id_token.fetch_id_token(self.auth_req, self.base_url)
                 from google.oauth2.credentials import Credentials
+
                 creds = Credentials(token)
             except Exception as e:
                 raise click.ClickException(
@@ -96,4 +98,3 @@ class IngestionHelperClient:
             return response.json()
         except Exception:
             return {"status": "success", "message": response.text}
-

--- a/packages/datacommons-admin/datacommons_admin/tf_utils.py
+++ b/packages/datacommons-admin/datacommons_admin/tf_utils.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import shutil
+import subprocess
+
+import click
+
+
+TF_OUTPUT_INGESTION_HELPER_URI = "dcp_ingestion_helper_uri"
+TF_OUTPUT_ORCHESTRATOR_SERVICE_ACCOUNT_EMAIL = "dcp_orchestrator_service_account_email"
+TF_OUTPUT_SPANNER_INSTANCE_ID = "dcp_spanner_instance_id"
+TF_OUTPUT_SPANNER_DATABASE_ID = "dcp_spanner_database_id"
+
+
+def get_terraform_output(key: str) -> str:
+    """Fetches a specific key from `terraform output -json` with graceful error handling."""
+    if not shutil.which("terraform"):
+        raise click.ClickException(
+            "Terraform CLI not found. Please ensure Terraform is installed and available in your PATH."
+        )
+
+    try:
+        result = subprocess.run(
+            ["terraform", "output", "-json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise click.ClickException(
+            f"Failed to run 'terraform output'. Are you in an initialized Terraform deployment directory?\n"
+            f"Error details: {e.stderr.strip() or e.stdout.strip()}"
+        )
+
+    try:
+        outputs = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        raise click.ClickException(
+            "Failed to parse 'terraform output -json'. The output was not valid JSON."
+        )
+
+    if not outputs:
+        from pathlib import Path
+
+        cwd = Path.cwd()
+        has_tf_files = (
+            (cwd / ".terraform").exists()
+            or (cwd / "terraform.tfstate").exists()
+            or (cwd / "main.tf").exists()
+        )
+
+        if not has_tf_files:
+            raise click.ClickException(
+                f"No Terraform outputs found in '{cwd}'.\n"
+                "Please navigate to your initialized DCP Terraform directory (e.g., 'cd my-namespace') and ensure 'terraform apply' has been run."
+            )
+        else:
+            raise click.ClickException(
+                f"No Terraform outputs found in '{cwd}'.\n"
+                "Please ensure you have successfully run 'terraform apply' to generate the deployment state."
+            )
+
+    if key not in outputs:
+        from pathlib import Path
+
+        raise click.ClickException(
+            f"Terraform output key '{key}' not found in '{Path.cwd()}'.\n"
+            "Please verify that your Terraform configuration exports this output and that 'terraform apply' was fully completed."
+        )
+
+    value = outputs[key].get("value")
+    if not value:
+        raise click.ClickException(
+            f"Terraform output '{key}' is empty or null. Please verify your deployment state."
+        )
+
+    return str(value)
+
+
+def get_dcp_ingestion_helper_uri() -> str:
+    """Convenience wrapper to fetch the dcp_ingestion_helper_uri Terraform output."""
+    return get_terraform_output(TF_OUTPUT_INGESTION_HELPER_URI)
+
+
+def get_dcp_orchestrator_service_account_email() -> str:
+    """Convenience wrapper to fetch the dcp_orchestrator_service_account_email Terraform output."""
+    return get_terraform_output(TF_OUTPUT_ORCHESTRATOR_SERVICE_ACCOUNT_EMAIL)
+
+
+def get_dcp_spanner_instance_id() -> str:
+    """Convenience wrapper to fetch the dcp_spanner_instance_id Terraform output."""
+    return get_terraform_output(TF_OUTPUT_SPANNER_INSTANCE_ID)
+
+
+def get_dcp_spanner_database_id() -> str:
+    """Convenience wrapper to fetch the dcp_spanner_database_id Terraform output."""
+    return get_terraform_output(TF_OUTPUT_SPANNER_DATABASE_ID)

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -126,3 +126,61 @@ def test_init_remote_state(
         assert (target_dir / "backend.tf").exists()
         backend_content = (target_dir / "backend.tf").read_text()
         assert 'bucket = "mock-bucket-name"' in backend_content
+
+
+@patch("datacommons_admin.tf_utils.shutil.which")
+def test_init_db_no_terraform(mock_which: patch, runner: CliRunner) -> None:
+    mock_which.return_value = None
+    result = runner.invoke(admin, ["init-db"])
+    assert result.exit_code != 0
+    assert "Terraform CLI not found" in result.output
+
+
+@patch("datacommons_admin.tf_utils.shutil.which")
+@patch("datacommons_admin.tf_utils.subprocess.run")
+def test_init_db_terraform_error(
+    mock_run: patch, mock_which: patch, runner: CliRunner
+) -> None:
+    mock_which.return_value = "terraform"
+    import subprocess
+
+    mock_run.side_effect = subprocess.CalledProcessError(
+        1, ["terraform"], stderr="not a terraform dir"
+    )
+    result = runner.invoke(admin, ["init-db"])
+    assert result.exit_code != 0
+    assert "Failed to run 'terraform output'" in result.output
+
+
+@patch("datacommons_admin.tf_utils.shutil.which")
+@patch("datacommons_admin.tf_utils.subprocess.run")
+@patch("datacommons_admin.ingestion_helper_client.AuthorizedSession")
+@patch("datacommons_admin.ingestion_helper_client.google.auth.default")
+def test_init_db_success(
+    mock_auth_default: patch,
+    mock_session: patch,
+    mock_run: patch,
+    mock_which: patch,
+    runner: CliRunner,
+) -> None:
+    mock_which.return_value = "terraform"
+    from unittest.mock import MagicMock
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = '{"dcp_ingestion_helper_uri": {"value": "https://mock-helper"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}, "dcp_spanner_instance_id": {"value": "mock-instance"}, "dcp_spanner_database_id": {"value": "mock-db"}}'
+    mock_run.return_value = mock_proc
+
+    mock_creds = MagicMock()
+    mock_auth_default.return_value = (mock_creds, "test-project")
+
+    mock_session_inst = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.ok = True
+    mock_resp.json.return_value = {"status": "success", "message": "DB Initialized"}
+    mock_session_inst.post.return_value = mock_resp
+    mock_session.return_value = mock_session_inst
+
+    result = runner.invoke(admin, ["init-db"])
+    assert result.exit_code == 0
+    assert "Successfully initialized Spanner database" in result.output
+

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -183,4 +183,3 @@ def test_init_db_success(
     result = runner.invoke(admin, ["init-db"])
     assert result.exit_code == 0
     assert "Successfully initialized Spanner database" in result.output
-


### PR DESCRIPTION
## Overview
- Adds a dedicated orchestrator service account (`dcp-orc-sa`) for CLI and Cloud Workflows execution, replacing broad project-wide IAM assignments with resource-scoped bindings.
- Adds `datacommons admin init-db` CLI to initialize spanner database via the ingestion helper service, authenticating using service account impersonation 

## Key Changes
### Terraform Infrastructure
* **Service Account Provisioning**: Created `google_service_account.dcp_orchestrator` in [dcp_ingestion_dataflow/main.tf](file:///Users/dwnoble/Projects/datacommons/datacommons/infra/dcp/modules/dcp_ingestion_dataflow/main.tf#L66-L70) to serve as the operator identity.
* **Resource-Scoped IAM**: Migrated project-level roles to resource-specific bindings:
  * `roles/run.invoker` on Cloud Run services ([dcp_ingestion_helper/main.tf](file:///Users/dwnoble/Projects/datacommons/datacommons/infra/dcp/modules/dcp_ingestion_helper/main.tf#L57-L63), [dcp_service/main.tf](file:///Users/dwnoble/Projects/datacommons/datacommons/infra/dcp/modules/dcp_service/main.tf#L76-L82)).
  * `roles/spanner.databaseUser` on Spanner databases ([spanner/main.tf](file:///Users/dwnoble/Projects/datacommons/datacommons/infra/dcp/modules/spanner/main.tf#L25-L31)).
  * `roles/storage.objectAdmin` on GCS buckets ([storage/main.tf](file:///Users/dwnoble/Projects/datacommons/datacommons/infra/dcp/modules/storage/main.tf#L22-L34)).
* **Output Wiring**: Exported orchestrator SA email, Spanner instance ID, and Spanner database ID through [stack/outputs.tf](file:///Users/dwnoble/Projects/datacommons/datacommons/infra/dcp/modules/stack/outputs.tf), [dcp/outputs.tf](file:///Users/dwnoble/Projects/datacommons/datacommons/infra/dcp/outputs.tf), [dan-seed-db/main.tf](file:///Users/dwnoble/Projects/datacommons/datacommons/dan-seed-db/main.tf), and [infra_templates.py](file:///Users/dwnoble/Projects/datacommons/datacommons/packages/datacommons-admin/datacommons_admin/infra_templates.py).
### CLI & Client Authentication (`datacommons-admin`)
* **Service Account Impersonation**: [IngestionHelperClient](file:///Users/dwnoble/Projects/datacommons/datacommons/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py#L24-L53) generates OIDC ID tokens via `impersonated_credentials.IDTokenCredentials`.
* **Output Parsing**: Added Terraform output getters for orchestrator SA and Spanner IDs in [tf_utils.py](file:///Users/dwnoble/Projects/datacommons/datacommons/packages/datacommons-admin/datacommons_admin/tf_utils.py).
* **UX & Logging**: Modified [init_db](file:///Users/dwnoble/Projects/datacommons/datacommons/packages/datacommons-admin/datacommons_admin/admin_cli.py#L254-L289) in [admin_cli.py](file:///Users/dwnoble/Projects/datacommons/datacommons/packages/datacommons-admin/datacommons_admin/admin_cli.py) to log target Spanner instance/database IDs and orchestrator SA details during database initialization.

* **Testing**: Updated unit tests in [test_admin_cli.py](file:///Users/dwnoble/Projects/datacommons/datacommons/packages/datacommons-admin/tests/test_admin_cli.py#L155-L187) to mock the new Terraform outputs.