### PR TITLE
Add seed-db CLI and integrate seeding into init-db

### DIFF
--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -119,7 +119,7 @@ def _configure_remote_state(resolved_project_id: str, resolved_namespace: str) -
 
 @click.group()
 def admin() -> None:
-    """Admin commands."""
+    """Manage a Data Commons Platform instance in Google Cloud"""
 
 
 @admin.command()
@@ -252,8 +252,11 @@ def init(
 
 
 @admin.command(name="init-db")
-def init_db() -> None:
-    """Initialize the Spanner database via the DCP Ingestion Helper service."""
+@click.option(
+    "--init-only", is_flag=True, help="Only initialize the database without seeding."
+)
+def init_db(init_only: bool) -> None:
+    """Initialize (and by default seed) the Spanner database via the DCP Ingestion Helper service."""
     click.secho("Datacommons Admin Init-DB", fg="cyan", bold=True)
     click.secho(
         "Fetching Ingestion Helper URI, Orchestrator Service Account, and Spanner details from Terraform outputs...",
@@ -288,5 +291,56 @@ def init_db() -> None:
     result = client.initialize_database()
 
     click.secho("Successfully initialized Spanner database!", fg="green", bold=True)
+    if "message" in result:
+        click.secho(f"Details: {result['message']}", fg="bright_black")
+
+    if not init_only:
+        click.secho(
+            f"Seeding Spanner database '{instance_id}/{database_id}' via the Ingestion Helper service...",
+            fg="bright_black",
+        )
+        seed_result = client.seed_database()
+        click.secho("Successfully seeded Spanner database!", fg="green", bold=True)
+        if "message" in seed_result:
+            click.secho(f"Details: {seed_result['message']}", fg="bright_black")
+
+
+@admin.command(name="seed-db")
+def seed_db() -> None:
+    """Seed the Spanner database via the DCP Ingestion Helper service."""
+    click.secho("Datacommons Admin Seed-DB", fg="cyan", bold=True)
+    click.secho(
+        "Fetching Ingestion Helper URI, Orchestrator Service Account, and Spanner details from Terraform outputs...",
+        fg="bright_black",
+    )
+
+    from datacommons_admin.tf_utils import (
+        get_dcp_ingestion_helper_uri,
+        get_dcp_orchestrator_service_account_email,
+        get_dcp_spanner_instance_id,
+        get_dcp_spanner_database_id,
+    )
+    from datacommons_admin.ingestion_helper_client import IngestionHelperClient
+
+    uri = get_dcp_ingestion_helper_uri()
+    sa_email = get_dcp_orchestrator_service_account_email()
+    instance_id = get_dcp_spanner_instance_id()
+    database_id = get_dcp_spanner_database_id()
+
+    click.secho(f"Found Ingestion Helper URI: {uri}", fg="green")
+    click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
+    click.secho(
+        f"Found Spanner Database Instance: {instance_id} / Database ID: {database_id}",
+        fg="green",
+    )
+    click.secho(
+        f"Seeding Spanner database '{instance_id}/{database_id}' via the Ingestion Helper service (this may take a few moments)...",
+        fg="bright_black",
+    )
+
+    client = IngestionHelperClient(uri, service_account_email=sa_email)
+    result = client.seed_database()
+
+    click.secho("Successfully seeded Spanner database!", fg="green", bold=True)
     if "message" in result:
         click.secho(f"Details: {result['message']}", fg="bright_black")

--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
+from typing import Any, Tuple
 
 import click
 from google.api_core import exceptions
@@ -251,6 +252,47 @@ def init(
     )
 
 
+def _setup_ingestion_client() -> Tuple[Any, str, str]:
+    click.secho(
+        "Fetching Ingestion Helper URI, Orchestrator Service Account, and Spanner details from Terraform outputs...",
+        fg="bright_black",
+    )
+
+    from datacommons_admin.tf_utils import (
+        get_dcp_ingestion_helper_uri,
+        get_dcp_orchestrator_service_account_email,
+        get_dcp_spanner_instance_id,
+        get_dcp_spanner_database_id,
+    )
+    from datacommons_admin.ingestion_helper_client import IngestionHelperClient
+
+    uri = get_dcp_ingestion_helper_uri()
+    sa_email = get_dcp_orchestrator_service_account_email()
+    instance_id = get_dcp_spanner_instance_id()
+    database_id = get_dcp_spanner_database_id()
+
+    click.secho(f"Found Ingestion Helper URI: {uri}", fg="green")
+    click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
+    click.secho(
+        f"Found Spanner Database Instance: {instance_id} / Database ID: {database_id}",
+        fg="green",
+    )
+
+    client = IngestionHelperClient(uri, service_account_email=sa_email)
+    return client, instance_id, database_id
+
+
+def _run_seed_db(client: Any, instance_id: str, database_id: str) -> None:
+    click.secho(
+        f"Seeding Spanner database '{instance_id}/{database_id}' via the Ingestion Helper service (this may take a few moments)...",
+        fg="bright_black",
+    )
+    result = client.seed_database()
+    click.secho("Successfully seeded Spanner database!", fg="green", bold=True)
+    if "message" in result:
+        click.secho(f"Details: {result['message']}", fg="bright_black")
+
+
 @admin.command(name="init-db")
 @click.option(
     "--init-only", is_flag=True, help="Only initialize the database without seeding."
@@ -258,36 +300,12 @@ def init(
 def init_db(init_only: bool) -> None:
     """Initialize (and by default seed) the Spanner database via the DCP Ingestion Helper service."""
     click.secho("Datacommons Admin Init-DB", fg="cyan", bold=True)
-    click.secho(
-        "Fetching Ingestion Helper URI, Orchestrator Service Account, and Spanner details from Terraform outputs...",
-        fg="bright_black",
-    )
+    client, instance_id, database_id = _setup_ingestion_client()
 
-    from datacommons_admin.tf_utils import (
-        get_dcp_ingestion_helper_uri,
-        get_dcp_orchestrator_service_account_email,
-        get_dcp_spanner_instance_id,
-        get_dcp_spanner_database_id,
-    )
-    from datacommons_admin.ingestion_helper_client import IngestionHelperClient
-
-    uri = get_dcp_ingestion_helper_uri()
-    sa_email = get_dcp_orchestrator_service_account_email()
-    instance_id = get_dcp_spanner_instance_id()
-    database_id = get_dcp_spanner_database_id()
-
-    click.secho(f"Found Ingestion Helper URI: {uri}", fg="green")
-    click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
-    click.secho(
-        f"Found Spanner Database Instance: {instance_id} / Database ID: {database_id}",
-        fg="green",
-    )
     click.secho(
         f"Initializing Spanner database '{instance_id}/{database_id}' via the Ingestion Helper service (this may take a few moments)...",
         fg="bright_black",
     )
-
-    client = IngestionHelperClient(uri, service_account_email=sa_email)
     result = client.initialize_database()
 
     click.secho("Successfully initialized Spanner database!", fg="green", bold=True)
@@ -295,52 +313,12 @@ def init_db(init_only: bool) -> None:
         click.secho(f"Details: {result['message']}", fg="bright_black")
 
     if not init_only:
-        click.secho(
-            f"Seeding Spanner database '{instance_id}/{database_id}' via the Ingestion Helper service...",
-            fg="bright_black",
-        )
-        seed_result = client.seed_database()
-        click.secho("Successfully seeded Spanner database!", fg="green", bold=True)
-        if "message" in seed_result:
-            click.secho(f"Details: {seed_result['message']}", fg="bright_black")
+        _run_seed_db(client, instance_id, database_id)
 
 
 @admin.command(name="seed-db")
 def seed_db() -> None:
     """Seed the Spanner database via the DCP Ingestion Helper service."""
     click.secho("Datacommons Admin Seed-DB", fg="cyan", bold=True)
-    click.secho(
-        "Fetching Ingestion Helper URI, Orchestrator Service Account, and Spanner details from Terraform outputs...",
-        fg="bright_black",
-    )
-
-    from datacommons_admin.tf_utils import (
-        get_dcp_ingestion_helper_uri,
-        get_dcp_orchestrator_service_account_email,
-        get_dcp_spanner_instance_id,
-        get_dcp_spanner_database_id,
-    )
-    from datacommons_admin.ingestion_helper_client import IngestionHelperClient
-
-    uri = get_dcp_ingestion_helper_uri()
-    sa_email = get_dcp_orchestrator_service_account_email()
-    instance_id = get_dcp_spanner_instance_id()
-    database_id = get_dcp_spanner_database_id()
-
-    click.secho(f"Found Ingestion Helper URI: {uri}", fg="green")
-    click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
-    click.secho(
-        f"Found Spanner Database Instance: {instance_id} / Database ID: {database_id}",
-        fg="green",
-    )
-    click.secho(
-        f"Seeding Spanner database '{instance_id}/{database_id}' via the Ingestion Helper service (this may take a few moments)...",
-        fg="bright_black",
-    )
-
-    client = IngestionHelperClient(uri, service_account_email=sa_email)
-    result = client.seed_database()
-
-    click.secho("Successfully seeded Spanner database!", fg="green", bold=True)
-    if "message" in result:
-        click.secho(f"Details: {result['message']}", fg="bright_black")
+    client, instance_id, database_id = _setup_ingestion_client()
+    _run_seed_db(client, instance_id, database_id)

--- a/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
+++ b/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
@@ -19,6 +19,7 @@ from google.oauth2 import id_token
 
 
 ACTION_INITIALIZE_DATABASE = "initialize_database"
+ACTION_SEED_DATABASE = "seed_database"
 
 
 class IngestionHelperClient:
@@ -58,10 +59,9 @@ class IngestionHelperClient:
 
         self.session = AuthorizedSession(creds)
 
-    def initialize_database(self) -> dict:
-        """Calls the initialize_database endpoint on the ingestion helper service."""
+    def _call_endpoint(self, action_type: str) -> dict:
         url = self.base_url
-        payload = {"actionType": ACTION_INITIALIZE_DATABASE}
+        payload = {"actionType": action_type}
 
         try:
             response = self.session.post(url, json=payload, timeout=300)
@@ -98,3 +98,11 @@ class IngestionHelperClient:
             return response.json()
         except Exception:
             return {"status": "success", "message": response.text}
+
+    def initialize_database(self) -> dict:
+        """Calls the initialize_database endpoint on the ingestion helper service."""
+        return self._call_endpoint(ACTION_INITIALIZE_DATABASE)
+
+    def seed_database(self) -> dict:
+        """Calls the seed_database endpoint on the ingestion helper service."""
+        return self._call_endpoint(ACTION_SEED_DATABASE)

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -183,3 +183,71 @@ def test_init_db_success(
     result = runner.invoke(admin, ["init-db"])
     assert result.exit_code == 0
     assert "Successfully initialized Spanner database" in result.output
+    assert "Successfully seeded Spanner database" in result.output
+
+
+@patch("datacommons_admin.tf_utils.shutil.which")
+@patch("datacommons_admin.tf_utils.subprocess.run")
+@patch("datacommons_admin.ingestion_helper_client.AuthorizedSession")
+@patch("datacommons_admin.ingestion_helper_client.google.auth.default")
+def test_init_db_init_only(
+    mock_auth_default: patch,
+    mock_session: patch,
+    mock_run: patch,
+    mock_which: patch,
+    runner: CliRunner,
+) -> None:
+    mock_which.return_value = "terraform"
+    from unittest.mock import MagicMock
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = '{"dcp_ingestion_helper_uri": {"value": "https://mock-helper"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}, "dcp_spanner_instance_id": {"value": "mock-instance"}, "dcp_spanner_database_id": {"value": "mock-db"}}'
+    mock_run.return_value = mock_proc
+
+    mock_creds = MagicMock()
+    mock_auth_default.return_value = (mock_creds, "test-project")
+
+    mock_session_inst = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.ok = True
+    mock_resp.json.return_value = {"status": "success", "message": "DB Initialized"}
+    mock_session_inst.post.return_value = mock_resp
+    mock_session.return_value = mock_session_inst
+
+    result = runner.invoke(admin, ["init-db", "--init-only"])
+    assert result.exit_code == 0
+    assert "Successfully initialized Spanner database" in result.output
+    assert "Seeding Spanner database" not in result.output
+
+
+@patch("datacommons_admin.tf_utils.shutil.which")
+@patch("datacommons_admin.tf_utils.subprocess.run")
+@patch("datacommons_admin.ingestion_helper_client.AuthorizedSession")
+@patch("datacommons_admin.ingestion_helper_client.google.auth.default")
+def test_seed_db_success(
+    mock_auth_default: patch,
+    mock_session: patch,
+    mock_run: patch,
+    mock_which: patch,
+    runner: CliRunner,
+) -> None:
+    mock_which.return_value = "terraform"
+    from unittest.mock import MagicMock
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = '{"dcp_ingestion_helper_uri": {"value": "https://mock-helper"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}, "dcp_spanner_instance_id": {"value": "mock-instance"}, "dcp_spanner_database_id": {"value": "mock-db"}}'
+    mock_run.return_value = mock_proc
+
+    mock_creds = MagicMock()
+    mock_auth_default.return_value = (mock_creds, "test-project")
+
+    mock_session_inst = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.ok = True
+    mock_resp.json.return_value = {"status": "success", "message": "DB Seeded"}
+    mock_session_inst.post.return_value = mock_resp
+    mock_session.return_value = mock_session_inst
+
+    result = runner.invoke(admin, ["seed-db"])
+    assert result.exit_code == 0
+    assert "Successfully seeded Spanner database" in result.output


### PR DESCRIPTION
Extends `datacommons-admin` and `IngestionHelperClient` to support Spanner database seeding via the DCP Ingestion Helper service.

### Key Changes
* **CLI**: 
  * Added `datacommons admin seed-db` command for explicit database seeding.
  * Updated `datacommons admin init-db` to execute seeding by default; added `--init-only` flag to override.
  * Updated root `admin` command help text.
* **Client**: Added `seed_database` method to `IngestionHelperClient` and consolidated HTTP request logic into `_call_endpoint`.
* **Tests**: Added test coverage for `seed-db`, `init-db --init-only`, and default `init-db` seeding behavior.