### PR TITLE
Admin cli ingest start, increased data ingest job timeout

### DIFF
--- a/infra/dcp/modules/cdc_data_ingestion_job/main.tf
+++ b/infra/dcp/modules/cdc_data_ingestion_job/main.tf
@@ -98,3 +98,20 @@ resource "null_resource" "run_db_init" {
 EOT
   }
 }
+
+resource "google_cloud_run_v2_job_iam_member" "orchestrator_viewer" {
+  count    = var.orchestrator_email != "" ? 1 : 0
+  location = google_cloud_run_v2_job.dc_data_job.location
+  name     = google_cloud_run_v2_job.dc_data_job.name
+  role     = "roles/run.viewer"
+  member   = "serviceAccount:${var.orchestrator_email}"
+}
+
+resource "google_cloud_run_v2_job_iam_member" "orchestrator_invoker" {
+  count    = var.orchestrator_email != "" ? 1 : 0
+  location = google_cloud_run_v2_job.dc_data_job.location
+  name     = google_cloud_run_v2_job.dc_data_job.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${var.orchestrator_email}"
+}
+

--- a/infra/dcp/modules/cdc_data_ingestion_job/variables.tf
+++ b/infra/dcp/modules/cdc_data_ingestion_job/variables.tf
@@ -13,6 +13,7 @@ variable "gcs_data_bucket_input_folder" { type = string }
 variable "gcs_data_bucket_output_folder" { type = string }
 variable "run_db_init" { type = bool }
 variable "use_spanner" { type = bool }
+variable "orchestrator_email" { type = string }
 
 variable "env_vars" {
   type = list(object({

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -296,6 +296,7 @@ module "cdc_data_ingestion_job" {
   use_spanner                   = local.cdc_use_spanner
   env_vars                      = local.cdc_cloud_run_shared_env_variables
   secret_env_vars               = local.cdc_cloud_run_shared_env_variable_secrets
+  orchestrator_email            = local.enable_dcp && var.dcp.deploy_data_ingestion_workflow && module.dcp_ingestion_dataflow[0].orchestrator_email != null ? module.dcp_ingestion_dataflow[0].orchestrator_email : ""
 
   depends_on = [module.cdc_iam]
 }

--- a/infra/dcp/modules/stack/outputs.tf
+++ b/infra/dcp/modules/stack/outputs.tf
@@ -48,3 +48,10 @@ output "dcp_orchestrator_service_account_email" {
   value       = var.toggles.enable_dcp && var.dcp.deploy_data_ingestion_workflow ? module.dcp_ingestion_dataflow[0].orchestrator_email : null
 }
 
+output "data_bucket_name" {
+  description = "Name of the GCS bucket used for CDC data ingestion"
+  value       = var.toggles.enable_cdc ? module.storage.cdc_bucket_name : null
+}
+
+
+

--- a/infra/dcp/outputs.tf
+++ b/infra/dcp/outputs.tf
@@ -48,3 +48,10 @@ output "dcp_orchestrator_service_account_email" {
   value       = module.stack.dcp_orchestrator_service_account_email
 }
 
+output "data_bucket_name" {
+  description = "Name of the GCS bucket used for CDC data ingestion"
+  value       = module.stack.data_bucket_name
+}
+
+
+

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -287,7 +287,7 @@ variable "cdc_data_job_memory" {
 variable "cdc_data_job_timeout" {
   description = "CDC data job timeout"
   type        = string
-  default     = "600s"
+  default     = "3600s"
 }
 
 variable "cdc_search_scope" {

--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -322,3 +322,8 @@ def seed_db() -> None:
     click.secho("Datacommons Admin Seed-DB", fg="cyan", bold=True)
     client, instance_id, database_id = _setup_ingestion_client()
     _run_seed_db(client, instance_id, database_id)
+
+
+from datacommons_admin.ingest_cli import ingest
+
+admin.add_command(ingest)

--- a/packages/datacommons-admin/datacommons_admin/infra_templates.py
+++ b/packages/datacommons-admin/datacommons_admin/infra_templates.py
@@ -41,6 +41,7 @@ module "datacommons_dcp" {{
   dcp_ingestion_helper_image         = var.dcp_ingestion_helper_image
   cdc_gcs_data_bucket_input_folder   = var.gcs_data_bucket_input_folder
   cdc_data_job_image                 = var.cdc_data_job_image
+  cdc_data_job_timeout               = var.cdc_data_job_timeout
 }}
 
 variable "project_id" {{
@@ -102,6 +103,12 @@ variable "cdc_data_job_image" {{
   default     = "gcr.io/datcom-ci/datacommons-data:stable"
 }}
 
+variable "cdc_data_job_timeout" {{
+  description = "Docker container timeout for the CDC data ingestion job"
+  type        = string
+  default     = "3600s"
+}}
+
 output "dcp_service_url" {{
   value = module.datacommons_dcp.dcp_service_url
 }}
@@ -133,7 +140,12 @@ output "workflow_name" {{
 output "dcp_orchestrator_service_account_email" {{
   value = module.datacommons_dcp.dcp_orchestrator_service_account_email
 }}
+
+output "data_bucket_name" {{
+  value = module.datacommons_dcp.data_bucket_name
+}}
 """
+
 
 TFVARS_TEMPLATE = """project_id = "{project_id}"
 namespace  = "{namespace}"
@@ -153,6 +165,9 @@ dcp_spanner_database_id     = "dcp-db"
 
 # Optional CDC Data Job image (defaults to stable)
 # cdc_data_job_image = "gcr.io/datcom-ci/datacommons-data:stable"
+
+# Optional CDC Data Job timeout (defaults to 3600s)
+# cdc_data_job_timeout = "3600s"
 """
 
 REMOTE_STATE_TEMPLATE = """

--- a/packages/datacommons-admin/datacommons_admin/ingest_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/ingest_cli.py
@@ -79,8 +79,6 @@ def start() -> None:
             click.secho(exec_url, fg="blue", underline=True)
 
 
-
-
 @ingest.command(name="show-config")
 def show_config() -> None:
     """Print the current ingestion job configuration (environment variables)."""

--- a/packages/datacommons-admin/datacommons_admin/ingest_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/ingest_cli.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+
+from datacommons_admin.ingestion_job_client import IngestionJobClient
+from datacommons_admin.tf_utils import (
+    get_cdc_data_job_name,
+    get_dcp_orchestrator_service_account_email,
+)
+
+
+@click.group(name="ingest")
+def ingest() -> None:
+    """Manage data ingestion jobs."""
+
+
+@ingest.command(name="start")
+def start() -> None:
+    """Start a data ingestion job execution."""
+    click.secho("Datacommons Admin Ingest Start", fg="cyan", bold=True)
+    click.secho(
+        "Fetching Data Job Name and Orchestrator Service Account from Terraform outputs...",
+        fg="bright_black",
+    )
+
+    job_name = get_cdc_data_job_name()
+    sa_email = get_dcp_orchestrator_service_account_email()
+
+    click.secho(f"Found Data Job Name: {job_name}", fg="green")
+    click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
+    click.secho(
+        f"Starting Cloud Run job '{job_name}' via Admin API (this may take a few moments)...",
+        fg="bright_black",
+    )
+
+    client = IngestionJobClient(job_name, service_account_email=sa_email)
+    result = client.start_job()
+
+    click.secho("Successfully started ingestion job!", fg="green", bold=True)
+    exec_name = result.get("name") or result.get("metadata", {}).get("name")
+    if exec_name:
+        click.secho(f"Execution details: {exec_name}", fg="bright_black")
+
+        parts = exec_name.split("/")
+        if (
+            len(parts) >= 8
+            and parts[0] == "projects"
+            and parts[2] == "locations"
+            and parts[4] == "jobs"
+            and parts[6] == "executions"
+        ):
+            project_id = parts[1]
+            location = parts[3]
+            job_id = parts[5]
+            execution_id = parts[7]
+
+            job_url = f"https://console.cloud.google.com/run/jobs/details/{location}/{job_id}/executions?project={project_id}"
+            exec_url = f"https://console.cloud.google.com/run/jobs/executions/details/{location}/{execution_id}?project={project_id}"
+
+            click.secho("Job ID: ", fg="cyan", bold=True, nl=False)
+            click.secho(job_id, fg="green")
+            click.secho("Execution ID: ", fg="cyan", bold=True, nl=False)
+            click.secho(execution_id, fg="green")
+            click.secho("Job Console Link: ", fg="cyan", bold=True, nl=False)
+            click.secho(job_url, fg="blue", underline=True)
+            click.secho("Execution Console Link: ", fg="cyan", bold=True, nl=False)
+            click.secho(exec_url, fg="blue", underline=True)
+
+
+
+
+@ingest.command(name="show-config")
+def show_config() -> None:
+    """Print the current ingestion job configuration (environment variables)."""
+    click.secho("Datacommons Admin Ingest Show-Config", fg="cyan", bold=True)
+    click.secho(
+        "Fetching Data Job Name and Orchestrator Service Account from Terraform outputs...",
+        fg="bright_black",
+    )
+
+    job_name = get_cdc_data_job_name()
+    sa_email = get_dcp_orchestrator_service_account_email()
+
+    click.secho(f"Found Data Job Name: {job_name}", fg="green")
+    click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
+    click.secho(
+        f"Fetching configuration for Cloud Run job '{job_name}'...",
+        fg="bright_black",
+    )
+
+    client = IngestionJobClient(job_name, service_account_email=sa_email)
+    env_vars = client.get_config()
+
+    click.secho("\nCurrent Ingestion Job Configuration:", fg="cyan", bold=True)
+    if not env_vars:
+        click.secho("No environment variables configured.", fg="yellow")
+    else:
+        for env in env_vars:
+            name = env.get("name", "UNKNOWN")
+            if "value" in env:
+                val = env["value"]
+            elif "valueSource" in env:
+                val = f"[SECRET: {env['valueSource']}]"
+            else:
+                val = "[UNSET]"
+            click.secho(f"  {name}: ", fg="bright_black", nl=False)
+            click.secho(str(val), fg="green")

--- a/packages/datacommons-admin/datacommons_admin/ingestion_job_client.py
+++ b/packages/datacommons-admin/datacommons_admin/ingestion_job_client.py
@@ -30,7 +30,9 @@ class IngestionJobClient:
                     "Could not determine GCP project ID from environment. Please verify your gcloud auth login."
                 )
             location = "us-central1"
-            self.full_job_name = f"projects/{project_id}/locations/{location}/jobs/{job_name}"
+            self.full_job_name = (
+                f"projects/{project_id}/locations/{location}/jobs/{job_name}"
+            )
         else:
             self.full_job_name = job_name
 
@@ -125,7 +127,9 @@ class IngestionJobClient:
         except Exception as e:
             raise click.ClickException(f"Failed to parse Cloud Run job response: {e}")
 
-        containers = job_data.get("template", {}).get("template", {}).get("containers", [])
+        containers = (
+            job_data.get("template", {}).get("template", {}).get("containers", [])
+        )
         if not containers:
             return []
 

--- a/packages/datacommons-admin/datacommons_admin/ingestion_job_client.py
+++ b/packages/datacommons-admin/datacommons_admin/ingestion_job_client.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+import google.auth
+from google.auth.transport.requests import AuthorizedSession
+
+
+class IngestionJobClient:
+    """Client for interacting with Cloud Run Admin API to manage CDC data ingestion jobs."""
+
+    def __init__(self, job_name: str, service_account_email: str = None) -> None:
+        self.service_account_email = service_account_email
+        base_credentials, project_id = google.auth.default()
+
+        if not job_name.startswith("projects/"):
+            if not project_id:
+                raise click.ClickException(
+                    "Could not determine GCP project ID from environment. Please verify your gcloud auth login."
+                )
+            location = "us-central1"
+            self.full_job_name = f"projects/{project_id}/locations/{location}/jobs/{job_name}"
+        else:
+            self.full_job_name = job_name
+
+        if service_account_email:
+            from google.auth import impersonated_credentials
+
+            creds = impersonated_credentials.Credentials(
+                source_credentials=base_credentials,
+                target_principal=service_account_email,
+                target_scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+        else:
+            creds = base_credentials
+
+        self.session = AuthorizedSession(creds)
+
+    def start_job(self) -> dict:
+        """Starts an execution of the Cloud Run job."""
+        url = f"https://run.googleapis.com/v2/{self.full_job_name}:run"
+        try:
+            response = self.session.post(url, json={}, timeout=300)
+        except Exception as e:
+            msg = f"Network or authentication error connecting to Cloud Run Admin API at {url}: {e}"
+            if self.service_account_email:
+                msg += f"\nFailed to impersonate {self.service_account_email}. Please ensure your GCP user account has the 'Service Account Token Creator' (roles/iam.serviceAccountTokenCreator) IAM role."
+            raise click.ClickException(msg)
+
+        if response.status_code == 401:
+            raise click.ClickException(
+                f"HTTP 401 Unauthorized when calling Cloud Run Admin API at {url}.\n"
+                "Your GCP credentials were rejected. Please verify your authentication.\n"
+                "To re-authenticate, run:\n"
+                "  gcloud auth application-default login"
+            )
+
+        if not response.ok:
+            try:
+                error_data = response.json()
+                error_msg = (
+                    error_data.get("message")
+                    or error_data.get("error", {}).get("message")
+                    or response.text
+                )
+            except Exception:
+                error_msg = response.text
+
+            raise click.ClickException(
+                f"Cloud Run Admin API returned HTTP {response.status_code}: {error_msg}"
+            )
+
+        try:
+            return response.json()
+        except Exception:
+            return {"status": "success", "message": response.text}
+
+    def get_config(self) -> list:
+        """Retrieves the environment variables configuration of the Cloud Run job."""
+        url = f"https://run.googleapis.com/v2/{self.full_job_name}"
+        try:
+            response = self.session.get(url, timeout=300)
+        except Exception as e:
+            msg = f"Network or authentication error connecting to Cloud Run Admin API at {url}: {e}"
+            if self.service_account_email:
+                msg += f"\nFailed to impersonate {self.service_account_email}. Please ensure your GCP user account has the 'Service Account Token Creator' (roles/iam.serviceAccountTokenCreator) IAM role."
+            raise click.ClickException(msg)
+
+        if response.status_code == 401:
+            raise click.ClickException(
+                f"HTTP 401 Unauthorized when calling Cloud Run Admin API at {url}.\n"
+                "Your GCP credentials were rejected. Please verify your authentication.\n"
+                "To re-authenticate, run:\n"
+                "  gcloud auth application-default login"
+            )
+
+        if not response.ok:
+            try:
+                error_data = response.json()
+                error_msg = (
+                    error_data.get("message")
+                    or error_data.get("error", {}).get("message")
+                    or response.text
+                )
+            except Exception:
+                error_msg = response.text
+
+            raise click.ClickException(
+                f"Cloud Run Admin API returned HTTP {response.status_code}: {error_msg}"
+            )
+
+        try:
+            job_data = response.json()
+        except Exception as e:
+            raise click.ClickException(f"Failed to parse Cloud Run job response: {e}")
+
+        containers = job_data.get("template", {}).get("template", {}).get("containers", [])
+        if not containers:
+            return []
+
+        return containers[0].get("env", [])

--- a/packages/datacommons-admin/datacommons_admin/tf_utils.py
+++ b/packages/datacommons-admin/datacommons_admin/tf_utils.py
@@ -23,6 +23,7 @@ TF_OUTPUT_INGESTION_HELPER_URI = "dcp_ingestion_helper_uri"
 TF_OUTPUT_ORCHESTRATOR_SERVICE_ACCOUNT_EMAIL = "dcp_orchestrator_service_account_email"
 TF_OUTPUT_SPANNER_INSTANCE_ID = "dcp_spanner_instance_id"
 TF_OUTPUT_SPANNER_DATABASE_ID = "dcp_spanner_database_id"
+TF_OUTPUT_CDC_DATA_JOB_NAME = "cdc_data_job_name"
 
 
 def get_terraform_output(key: str) -> str:
@@ -108,3 +109,8 @@ def get_dcp_spanner_instance_id() -> str:
 def get_dcp_spanner_database_id() -> str:
     """Convenience wrapper to fetch the dcp_spanner_database_id Terraform output."""
     return get_terraform_output(TF_OUTPUT_SPANNER_DATABASE_ID)
+
+
+def get_cdc_data_job_name() -> str:
+    """Convenience wrapper to fetch the cdc_data_job_name Terraform output."""
+    return get_terraform_output(TF_OUTPUT_CDC_DATA_JOB_NAME)

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -277,19 +277,29 @@ def test_ingest_start_success(
     mock_session_inst = MagicMock()
     mock_resp = MagicMock()
     mock_resp.ok = True
-    mock_resp.json.return_value = {"name": "projects/mock-proj/locations/us-central1/jobs/mock-job/executions/exec-123"}
+    mock_resp.json.return_value = {
+        "name": "projects/mock-proj/locations/us-central1/jobs/mock-job/executions/exec-123"
+    }
     mock_session_inst.post.return_value = mock_resp
     mock_session.return_value = mock_session_inst
 
     result = runner.invoke(admin, ["ingest", "start"])
     assert result.exit_code == 0
     assert "Successfully started ingestion job!" in result.output
-    assert "Execution details: projects/mock-proj/locations/us-central1/jobs/mock-job/executions/exec-123" in result.output
+    assert (
+        "Execution details: projects/mock-proj/locations/us-central1/jobs/mock-job/executions/exec-123"
+        in result.output
+    )
     assert "Job ID: mock-job" in result.output
     assert "Execution ID: exec-123" in result.output
-    assert "Job Console Link: https://console.cloud.google.com/run/jobs/details/us-central1/mock-job/executions?project=mock-proj" in result.output
-    assert "Execution Console Link: https://console.cloud.google.com/run/jobs/executions/details/us-central1/exec-123?project=mock-proj" in result.output
-
+    assert (
+        "Job Console Link: https://console.cloud.google.com/run/jobs/details/us-central1/mock-job/executions?project=mock-proj"
+        in result.output
+    )
+    assert (
+        "Execution Console Link: https://console.cloud.google.com/run/jobs/executions/details/us-central1/exec-123?project=mock-proj"
+        in result.output
+    )
 
 
 @patch("datacommons_admin.tf_utils.shutil.which")
@@ -337,4 +347,3 @@ def test_ingest_show_config_success(
     assert result.exit_code == 0
     assert "GCS_BUCKET: my-test-bucket" in result.output
     assert "API_KEY: [SECRET: secret-api-key]" in result.output
-

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -251,3 +251,90 @@ def test_seed_db_success(
     result = runner.invoke(admin, ["seed-db"])
     assert result.exit_code == 0
     assert "Successfully seeded Spanner database" in result.output
+
+
+@patch("datacommons_admin.tf_utils.shutil.which")
+@patch("datacommons_admin.tf_utils.subprocess.run")
+@patch("datacommons_admin.ingestion_job_client.AuthorizedSession")
+@patch("datacommons_admin.ingestion_job_client.google.auth.default")
+def test_ingest_start_success(
+    mock_auth_default: patch,
+    mock_session: patch,
+    mock_run: patch,
+    mock_which: patch,
+    runner: CliRunner,
+) -> None:
+    mock_which.return_value = "terraform"
+    from unittest.mock import MagicMock
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = '{"cdc_data_job_name": {"value": "projects/mock-proj/locations/us-central1/jobs/mock-job"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}}'
+    mock_run.return_value = mock_proc
+
+    mock_creds = MagicMock()
+    mock_auth_default.return_value = (mock_creds, "test-project")
+
+    mock_session_inst = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.ok = True
+    mock_resp.json.return_value = {"name": "projects/mock-proj/locations/us-central1/jobs/mock-job/executions/exec-123"}
+    mock_session_inst.post.return_value = mock_resp
+    mock_session.return_value = mock_session_inst
+
+    result = runner.invoke(admin, ["ingest", "start"])
+    assert result.exit_code == 0
+    assert "Successfully started ingestion job!" in result.output
+    assert "Execution details: projects/mock-proj/locations/us-central1/jobs/mock-job/executions/exec-123" in result.output
+    assert "Job ID: mock-job" in result.output
+    assert "Execution ID: exec-123" in result.output
+    assert "Job Console Link: https://console.cloud.google.com/run/jobs/details/us-central1/mock-job/executions?project=mock-proj" in result.output
+    assert "Execution Console Link: https://console.cloud.google.com/run/jobs/executions/details/us-central1/exec-123?project=mock-proj" in result.output
+
+
+
+@patch("datacommons_admin.tf_utils.shutil.which")
+@patch("datacommons_admin.tf_utils.subprocess.run")
+@patch("datacommons_admin.ingestion_job_client.AuthorizedSession")
+@patch("datacommons_admin.ingestion_job_client.google.auth.default")
+def test_ingest_show_config_success(
+    mock_auth_default: patch,
+    mock_session: patch,
+    mock_run: patch,
+    mock_which: patch,
+    runner: CliRunner,
+) -> None:
+    mock_which.return_value = "terraform"
+    from unittest.mock import MagicMock
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = '{"cdc_data_job_name": {"value": "mock-job"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}}'
+    mock_run.return_value = mock_proc
+
+    mock_creds = MagicMock()
+    mock_auth_default.return_value = (mock_creds, "test-project")
+
+    mock_session_inst = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.ok = True
+    mock_resp.json.return_value = {
+        "template": {
+            "template": {
+                "containers": [
+                    {
+                        "env": [
+                            {"name": "GCS_BUCKET", "value": "my-test-bucket"},
+                            {"name": "API_KEY", "valueSource": "secret-api-key"},
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+    mock_session_inst.get.return_value = mock_resp
+    mock_session.return_value = mock_session_inst
+
+    result = runner.invoke(admin, ["ingest", "show-config"])
+    assert result.exit_code == 0
+    assert "GCS_BUCKET: my-test-bucket" in result.output
+    assert "API_KEY: [SECRET: secret-api-key]" in result.output
+


### PR DESCRIPTION

#### Changes
* **Command Group**: Added `datacommons admin ingest` with `start` (initiates job execution and outputs direct GCP Console links) and `show-config` (displays current environment variables and secret references).
* **API Client**: Implemented `IngestionJobClient` using `AuthorizedSession` and service account impersonation to interact with the Cloud Run Admin API v2 (`run.jobs.run` and `run.jobs.get`).
* **Terraform Helper**: Added `get_cdc_data_job_name` wrapper to fetch the job ID from deployment state.
#### Infrastructure & Templates (`infra/dcp`)
* **IAM Bindings**: Granted `roles/run.viewer` and `roles/run.invoker` to the DCP Orchestrator service account on the CDC data ingestion job.
* **Configuration Tuning**: Increased default CDC data job timeout from `600s` to `3600s` (1 hour) in `variables.tf` and exposed `cdc_data_job_timeout` in scaffolding templates.
* **Storage Outputs**: Exported `data_bucket_name` at the module and root levels to expose the CDC ingestion bucket name.
#### Tests
* Added unit tests for `ingest start` and `ingest show-config` flows, verifying mock API responses, ID parsing, and console link generation