### PR TITLE
Enhance ingest start with Workflow console links

### DIFF
--- a/packages/datacommons-admin/datacommons_admin/ingest_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/ingest_cli.py
@@ -20,6 +20,7 @@ from datacommons_admin.tf_utils import (
     get_dcp_orchestrator_service_account_email,
     get_dcp_project_id,
     get_dcp_region,
+    get_dcp_workflow_name,
 )
 
 
@@ -41,6 +42,7 @@ def start() -> None:
     sa_email = get_dcp_orchestrator_service_account_email()
     project_id = get_dcp_project_id()
     region = get_dcp_region()
+    workflow_name = get_dcp_workflow_name()
 
     click.secho(f"Found Data Job Name: {job_name}", fg="green")
     click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
@@ -81,6 +83,17 @@ def start() -> None:
             click.secho(job_url, fg="blue", underline=True)
         else:
             click.secho(f"Resource details: {res_name}", fg="bright_black")
+
+        click.secho("\n[!] Note on Ingestion Completion", fg="yellow", bold=True)
+        click.secho(
+            "This job triggers a Cloud Workflow that runs in the background.\n"
+            "Check the Workflows console below to verify full completion.",
+            fg="yellow"
+        )
+        
+        workflow_url = f"https://console.cloud.google.com/workflows/workflow/{region}/{workflow_name}/executions?project={project_id}"
+        click.secho("Workflow Console Link: ", fg="cyan", bold=True, nl=False)
+        click.secho(workflow_url, fg="blue", underline=True)
 
 
 @ingest.command(name="show-config")

--- a/packages/datacommons-admin/datacommons_admin/ingest_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/ingest_cli.py
@@ -59,53 +59,28 @@ def start() -> None:
     )
     result = client.start_job()
 
+    import re
+
     click.secho("Successfully started ingestion job!", fg="green", bold=True)
-    exec_name = result.get("name") or result.get("metadata", {}).get("name")
-    if exec_name:
-        click.secho(f"Execution details: {exec_name}", fg="bright_black")
+    res_name = result.get("name") or result.get("metadata", {}).get("name")
+    
+    if res_name:
+        op_pattern = r"projects/([^/]+)/locations/([^/]+)/operations/([^/]+)"
+        op_match = re.match(op_pattern, res_name)
 
-        parts = exec_name.split("/")
-        if (
-            len(parts) >= 8
-            and parts[0] == "projects"
-            and parts[2] == "locations"
-            and parts[4] == "jobs"
-            and parts[6] == "executions"
-        ):
-            project_id = parts[1]
-            location = parts[3]
-            job_id = parts[5]
-            execution_id = parts[7]
-
-            job_url = f"https://console.cloud.google.com/run/jobs/details/{location}/{job_id}/executions?project={project_id}"
-            exec_url = f"https://console.cloud.google.com/run/jobs/executions/details/{location}/{execution_id}?project={project_id}"
-
-            click.secho("Job ID: ", fg="cyan", bold=True, nl=False)
-            click.secho(job_id, fg="green")
-            click.secho("Execution ID: ", fg="cyan", bold=True, nl=False)
-            click.secho(execution_id, fg="green")
-            click.secho("Job Console Link: ", fg="cyan", bold=True, nl=False)
-            click.secho(job_url, fg="blue", underline=True)
-            click.secho("Execution Console Link: ", fg="cyan", bold=True, nl=False)
-            click.secho(exec_url, fg="blue", underline=True)
-        elif (
-            len(parts) >= 6
-            and parts[0] == "projects"
-            and parts[2] == "locations"
-            and parts[4] == "operations"
-        ):
-            resp_project_id = parts[1]
-            location = parts[3]
-            operation_id = parts[5]
-
+        if op_match:
+            click.secho(f"Operation details: {res_name}", fg="bright_black")
+            resp_project_id, location, operation_id = op_match.groups()
+            
             short_job_name = job_name.split("/")[-1] if "/" in job_name else job_name
-
             job_url = f"https://console.cloud.google.com/run/jobs/details/{location}/{short_job_name}/executions?project={resp_project_id}"
 
-            click.secho("Job Console Link: ", fg="cyan", bold=True, nl=False)
-            click.secho(job_url, fg="blue", underline=True)
             click.secho("Operation ID: ", fg="cyan", bold=True, nl=False)
             click.secho(operation_id, fg="green")
+            click.secho("Job Console Link: ", fg="cyan", bold=True, nl=False)
+            click.secho(job_url, fg="blue", underline=True)
+        else:
+            click.secho(f"Resource details: {res_name}", fg="bright_black")
 
 
 @ingest.command(name="show-config")

--- a/packages/datacommons-admin/datacommons_admin/ingest_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/ingest_cli.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import click
+import re
 
 from datacommons_admin.ingestion_job_client import IngestionJobClient
 from datacommons_admin.tf_utils import (
@@ -61,11 +62,9 @@ def start() -> None:
     )
     result = client.start_job()
 
-    import re
-
     click.secho("Successfully started ingestion job!", fg="green", bold=True)
     res_name = result.get("name") or result.get("metadata", {}).get("name")
-    
+
     if res_name:
         op_pattern = r"projects/([^/]+)/locations/([^/]+)/operations/([^/]+)"
         op_match = re.match(op_pattern, res_name)
@@ -73,7 +72,7 @@ def start() -> None:
         if op_match:
             click.secho(f"Operation details: {res_name}", fg="bright_black")
             resp_project_id, location, operation_id = op_match.groups()
-            
+
             short_job_name = job_name.split("/")[-1] if "/" in job_name else job_name
             job_url = f"https://console.cloud.google.com/run/jobs/details/{location}/{short_job_name}/executions?project={resp_project_id}"
 
@@ -88,9 +87,9 @@ def start() -> None:
         click.secho(
             "This job triggers a Cloud Workflow that runs in the background.\n"
             "Check the Workflows console below to verify full completion.",
-            fg="yellow"
+            fg="yellow",
         )
-        
+
         workflow_url = f"https://console.cloud.google.com/workflows/workflow/{region}/{workflow_name}/executions?project={project_id}"
         click.secho("Workflow Console Link: ", fg="cyan", bold=True, nl=False)
         click.secho(workflow_url, fg="blue", underline=True)

--- a/packages/datacommons-admin/datacommons_admin/tf_utils.py
+++ b/packages/datacommons-admin/datacommons_admin/tf_utils.py
@@ -26,6 +26,7 @@ TF_OUTPUT_SPANNER_DATABASE_ID = "dcp_spanner_database_id"
 TF_OUTPUT_CDC_DATA_JOB_NAME = "cdc_data_job_name"
 TF_OUTPUT_PROJECT_ID = "project_id"
 TF_OUTPUT_REGION = "region"
+TF_OUTPUT_WORKFLOW_NAME = "workflow_name"
 
 
 def get_terraform_output(key: str) -> str:
@@ -126,3 +127,8 @@ def get_dcp_project_id() -> str:
 def get_dcp_region() -> str:
     """Convenience wrapper to fetch the region Terraform output."""
     return get_terraform_output(TF_OUTPUT_REGION)
+
+
+def get_dcp_workflow_name() -> str:
+    """Convenience wrapper to fetch the workflow_name Terraform output."""
+    return get_terraform_output(TF_OUTPUT_WORKFLOW_NAME)

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -312,7 +312,7 @@ def test_ingest_start_success(
     mock_resp = MagicMock()
     mock_resp.ok = True
     mock_resp.json.return_value = {
-        "name": "projects/mock-proj/locations/us-central1/jobs/mock-job/executions/exec-123"
+        "name": "projects/mock-proj/locations/us-central1/operations/op-123"
     }
     mock_session_inst.post.return_value = mock_resp
     mock_session.return_value = mock_session_inst
@@ -321,17 +321,12 @@ def test_ingest_start_success(
     assert result.exit_code == 0
     assert "Successfully started ingestion job!" in result.output
     assert (
-        "Execution details: projects/mock-proj/locations/us-central1/jobs/mock-job/executions/exec-123"
+        "Operation details: projects/mock-proj/locations/us-central1/operations/op-123"
         in result.output
     )
-    assert "Job ID: mock-job" in result.output
-    assert "Execution ID: exec-123" in result.output
+    assert "Operation ID: op-123" in result.output
     assert (
         "Job Console Link: https://console.cloud.google.com/run/jobs/details/us-central1/mock-job/executions?project=mock-proj"
-        in result.output
-    )
-    assert (
-        "Execution Console Link: https://console.cloud.google.com/run/jobs/executions/details/us-central1/exec-123?project=mock-proj"
         in result.output
     )
 

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -302,7 +302,7 @@ def test_ingest_start_success(
     from unittest.mock import MagicMock
 
     mock_proc = MagicMock()
-    mock_proc.stdout = '{"cdc_data_job_name": {"value": "projects/mock-proj/locations/us-central1/jobs/mock-job"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}, "project_id": {"value": "mock-proj"}, "region": {"value": "us-central1"}}'
+    mock_proc.stdout = '{"cdc_data_job_name": {"value": "projects/mock-proj/locations/us-central1/jobs/mock-job"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}, "project_id": {"value": "mock-proj"}, "region": {"value": "us-central1"}, "workflow_name": {"value": "mock-workflow"}}'
     mock_run.return_value = mock_proc
 
     mock_creds = MagicMock()


### PR DESCRIPTION
* **Refined Job Console Links**: Updated ingest start to use regex for cleaner parsing of operation responses and constructed accurate console links.
* **Added Cloud Workflow Details**: Added a post-execution note and a direct console link to the triggered Cloud Workflow, making it clear that processing continues in the background.

Output Example:
```
Operation ID: f8fb31c8-aa98-4bb0-8142-b6337ba22d14
Job Console Link: https://console.cloud.google.com/run/jobs/details/us-central1/calinc-uvx-datacommons-data-job/executions?project=datcom-website-dev

[!] Note on Ingestion Completion
This job triggers a Cloud Workflow that runs in the background.
Check the Workflows console below to verify full completion.
Workflow Console Link: https://console.cloud.google.com/workflows/workflow/us-central1/calinc-uvx-ingestion-orchestrator/executions?project=datcom-website-dev
```