### PR TITLE
Adds the bq reservation resource

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -78,6 +78,8 @@ locals {
     spanner_database_id            = var.dcp_spanner_database_id
     spanner_version_retention_period = var.dcp_spanner_version_retention_period
     create_bq_reservation           = var.dcp_create_bq_reservation
+    bq_reservation_slot_capacity     = var.dcp_bq_reservation_slot_capacity
+    bq_reservation_max_slots        = var.dcp_bq_reservation_max_slots
     spanner_processing_units       = var.dcp_spanner_processing_units
     service_cpu                    = var.dcp_service_cpu
     service_memory                 = var.dcp_service_memory

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -46,7 +46,8 @@ resource "google_project_service" "apis" {
     "dataflow.googleapis.com"
     ] : [], var.enable_bq_federation ? [
     "bigqueryconnection.googleapis.com",
-    "bigquery.googleapis.com"
+    "bigquery.googleapis.com",
+    "bigqueryreservation.googleapis.com"
   ] : []))
 
   service            = each.key
@@ -76,6 +77,7 @@ locals {
     spanner_instance_id            = var.dcp_spanner_instance_id
     spanner_database_id            = var.dcp_spanner_database_id
     spanner_version_retention_period = var.dcp_spanner_version_retention_period
+    create_bq_reservation           = var.create_bq_reservation
     spanner_processing_units       = var.dcp_spanner_processing_units
     service_cpu                    = var.dcp_service_cpu
     service_memory                 = var.dcp_service_memory

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -44,7 +44,7 @@ resource "google_project_service" "apis" {
     "workflows.googleapis.com",
     "workflowexecutions.googleapis.com",
     "dataflow.googleapis.com"
-    ] : [], var.enable_bq_federation ? [
+    ] : [], var.dcp_enable_bq_federation ? [
     "bigqueryconnection.googleapis.com",
     "bigquery.googleapis.com",
     "bigqueryreservation.googleapis.com"
@@ -77,7 +77,7 @@ locals {
     spanner_instance_id            = var.dcp_spanner_instance_id
     spanner_database_id            = var.dcp_spanner_database_id
     spanner_version_retention_period = var.dcp_spanner_version_retention_period
-    create_bq_reservation           = var.create_bq_reservation
+    create_bq_reservation           = var.dcp_create_bq_reservation
     spanner_processing_units       = var.dcp_spanner_processing_units
     service_cpu                    = var.dcp_service_cpu
     service_memory                 = var.dcp_service_memory
@@ -90,8 +90,8 @@ locals {
     external_ingestion_bucket_name = var.dcp_external_ingestion_bucket_name
     ingestion_lock_timeout         = var.dcp_ingestion_lock_timeout
     ingestion_helper_image         = var.dcp_ingestion_helper_image
-    enable_bq_federation           = var.enable_bq_federation
-    bq_connection_name             = var.bq_connection_name
+    enable_bq_federation           = var.dcp_enable_bq_federation
+    bq_connection_name             = var.dcp_bq_connection_name
   }
 
   stack_cdc = {

--- a/infra/dcp/modules/spanner/bq_reservation.tf
+++ b/infra/dcp/modules/spanner/bq_reservation.tf
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create the BigQuery Reservation for Federation queries
+resource "google_bigquery_reservation" "default" {
+  count         = var.create_spanner_db && var.enable_bq_federation ? 1 : 0
+  name          = "default"
+  location      = var.region
+  edition       = "ENTERPRISE"
+  slot_capacity = 100
+
+  autoscale {
+    max_slots = 400
+  }
+}
+
+# Assign the reservation to the project for queries
+resource "google_bigquery_reservation_assignment" "project_assignment" {
+  count       = var.create_spanner_db && var.enable_bq_federation ? 1 : 0
+  reservation = google_bigquery_reservation.default[0].id
+  assignee    = "projects/${var.project_id}"
+  job_type    = "QUERY"
+}

--- a/infra/dcp/modules/spanner/bq_reservation.tf
+++ b/infra/dcp/modules/spanner/bq_reservation.tf
@@ -14,7 +14,7 @@
 
 # Create the BigQuery Reservation for Federation queries
 resource "google_bigquery_reservation" "default" {
-  count         = var.create_spanner_db && var.enable_bq_federation ? 1 : 0
+  count         = var.create_spanner_db && var.enable_bq_federation && var.create_bq_reservation ? 1 : 0
   name          = "default"
   location      = var.region
   edition       = "ENTERPRISE"
@@ -27,7 +27,7 @@ resource "google_bigquery_reservation" "default" {
 
 # Assign the reservation to the project for queries
 resource "google_bigquery_reservation_assignment" "project_assignment" {
-  count       = var.create_spanner_db && var.enable_bq_federation ? 1 : 0
+  count       = var.create_spanner_db && var.enable_bq_federation && var.create_bq_reservation ? 1 : 0
   reservation = google_bigquery_reservation.default[0].id
   assignee    = "projects/${var.project_id}"
   job_type    = "QUERY"

--- a/infra/dcp/modules/spanner/bq_reservation.tf
+++ b/infra/dcp/modules/spanner/bq_reservation.tf
@@ -18,10 +18,10 @@ resource "google_bigquery_reservation" "default" {
   name          = "default"
   location      = var.region
   edition       = "ENTERPRISE"
-  slot_capacity = 100
+  slot_capacity = var.bq_reservation_slot_capacity
 
   autoscale {
-    max_slots = 400
+    max_slots = var.bq_reservation_max_slots
   }
 }
 

--- a/infra/dcp/modules/spanner/variables.tf
+++ b/infra/dcp/modules/spanner/variables.tf
@@ -74,7 +74,7 @@ variable "create_bq_reservation" {
 variable "bq_reservation_slot_capacity" {
   type        = number
   description = "Baseline slots for BigQuery reservation"
-  default     = 100
+  default     = 0
 }
 
 variable "bq_reservation_max_slots" {

--- a/infra/dcp/modules/spanner/variables.tf
+++ b/infra/dcp/modules/spanner/variables.tf
@@ -64,3 +64,9 @@ variable "spanner_version_retention_period" {
   description = "The version retention period for the Spanner database"
   default     = "6h"
 }
+
+variable "create_bq_reservation" {
+  type        = bool
+  description = "Create a new BigQuery reservation for federation queries"
+  default     = true
+}

--- a/infra/dcp/modules/spanner/variables.tf
+++ b/infra/dcp/modules/spanner/variables.tf
@@ -70,3 +70,15 @@ variable "create_bq_reservation" {
   description = "Create a new BigQuery reservation for federation queries"
   default     = true
 }
+
+variable "bq_reservation_slot_capacity" {
+  type        = number
+  description = "Baseline slots for BigQuery reservation"
+  default     = 100
+}
+
+variable "bq_reservation_max_slots" {
+  type        = number
+  description = "Max slots for BigQuery reservation autoscale"
+  default     = 400
+}

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -130,6 +130,8 @@ module "spanner" {
   ingestion_helper_sa_email = local.enable_dcp && var.dcp.deploy_data_ingestion_workflow ? module.dcp_ingestion_dataflow[0].ingestion_runner_email : ""
   spanner_version_retention_period = var.dcp.spanner_version_retention_period
   create_bq_reservation           = var.dcp.create_bq_reservation
+  bq_reservation_slot_capacity     = var.dcp.bq_reservation_slot_capacity
+  bq_reservation_max_slots        = var.dcp.bq_reservation_max_slots
 }
 
 module "dcp_service" {

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -129,6 +129,7 @@ module "spanner" {
   bq_connection_name         = var.dcp.bq_connection_name
   ingestion_helper_sa_email = local.enable_dcp && var.dcp.deploy_data_ingestion_workflow ? module.dcp_ingestion_dataflow[0].ingestion_runner_email : ""
   spanner_version_retention_period = var.dcp.spanner_version_retention_period
+  create_bq_reservation           = var.dcp.create_bq_reservation
 }
 
 module "dcp_service" {

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -34,6 +34,7 @@ variable "dcp" {
     deploy_data_ingestion_workflow = bool
     create_ingestion_bucket         = bool
     spanner_version_retention_period = string
+    create_bq_reservation           = bool
     external_ingestion_bucket_name  = string
     ingestion_lock_timeout          = number
     ingestion_helper_image          = string

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -35,6 +35,8 @@ variable "dcp" {
     create_ingestion_bucket         = bool
     spanner_version_retention_period = string
     create_bq_reservation           = bool
+    bq_reservation_slot_capacity     = number
+    bq_reservation_max_slots        = number
     external_ingestion_bucket_name  = string
     ingestion_lock_timeout          = number
     ingestion_helper_image          = string

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -302,19 +302,19 @@ variable "cdc_search_scope" {
   default     = "base_and_custom"
 }
 
-variable "enable_bq_federation" {
+variable "dcp_enable_bq_federation" {
   description = "Enable BigQuery federation to Spanner"
   type        = bool
   default     = false
 }
 
-variable "bq_connection_name" {
+variable "dcp_bq_connection_name" {
   description = "BigQuery connection name for Spanner"
   type        = string
   default     = "spanner_connection"
 }
 
-variable "create_bq_reservation" {
+variable "dcp_create_bq_reservation" {
   description = "Create a new BigQuery reservation for federation queries"
   type        = bool
   default     = true

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -323,7 +323,7 @@ variable "dcp_create_bq_reservation" {
 variable "dcp_bq_reservation_slot_capacity" {
   description = "Baseline slots for BigQuery reservation"
   type        = number
-  default     = 100
+  default     = 0
 }
 
 variable "dcp_bq_reservation_max_slots" {

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -320,6 +320,18 @@ variable "dcp_create_bq_reservation" {
   default     = true
 }
 
+variable "dcp_bq_reservation_slot_capacity" {
+  description = "Baseline slots for BigQuery reservation"
+  type        = number
+  default     = 100
+}
+
+variable "dcp_bq_reservation_max_slots" {
+  description = "Max slots for BigQuery reservation autoscale"
+  type        = number
+  default     = 400
+}
+
 variable "cdc_enable_mcp" {
   description = "CDC enable MCP"
   type        = bool

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -314,6 +314,12 @@ variable "bq_connection_name" {
   default     = "spanner_connection"
 }
 
+variable "create_bq_reservation" {
+  description = "Create a new BigQuery reservation for federation queries"
+  type        = bool
+  default     = true
+}
+
 variable "cdc_enable_mcp" {
   description = "CDC enable MCP"
   type        = bool


### PR DESCRIPTION
This PR fixes the creation of the Bigquery reservation, and the assignment. 
It also adds a variable to disable the bigquery reservation entirely since we just need one per GCP project, without the need to connect it to any job. 
And it adds variables for the slots. 