### PR TITLE
Fixed datacommons-api docker entrypoint

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,9 @@ COPY packages/ ./packages/
 
 # Install the dependencies and the project itself
 # uv sync --frozen installs everything from the lockfile.
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --all-packages
+
+
 
 # Place the virtualenv in the PATH
 ENV PATH="/app/.venv/bin:$PATH"
@@ -27,5 +29,5 @@ USER datacommons-runner
 EXPOSE 5000
 
 # Set the entrypoint to the CLI
-ENTRYPOINT ["datacommons", "api"]
+ENTRYPOINT ["datacommons-api"]
 CMD ["start", "--host", "0.0.0.0", "--port", "5000"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@ COPY packages/ ./packages/
 
 # Install the dependencies and the project itself
 # uv sync --frozen installs everything from the lockfile.
-RUN uv sync --frozen --no-dev --package datacommons-api
+RUN uv sync --frozen --no-dev --package datacommons-api --no-cache
 
 
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,8 @@ COPY packages/ ./packages/
 
 # Install the dependencies and the project itself
 # uv sync --frozen installs everything from the lockfile.
-RUN uv sync --frozen --no-dev --all-packages
+RUN uv sync --frozen --no-dev --package datacommons-api
+
 
 
 


### PR DESCRIPTION
This pull request makes minor updates to the `build/Dockerfile` to improve dependency installation and update the application entrypoint.

- Entrypoint update:
  * The Docker entrypoint command has been changed from `["datacommons", "api"]` to `["datacommons-api"]` to match the correct executable.