### PR TITLE
[DCP - MCP] Store the MCP Server custom instructions in input/mcp_instructions

### DIFF
--- a/infra/dcp/backup_gabe/backend.tf
+++ b/infra/dcp/backup_gabe/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "datacommons-platform-tf-state-1"
+    prefix = "terraform/state"
+  }
+}

--- a/infra/dcp/backup_gabe/backend.tf
+++ b/infra/dcp/backup_gabe/backend.tf
@@ -1,6 +1,0 @@
-terraform {
-  backend "gcs" {
-    bucket = "datacommons-platform-tf-state-1"
-    prefix = "terraform/state"
-  }
-}

--- a/infra/dcp/modules/cdc_services/main.tf
+++ b/infra/dcp/modules/cdc_services/main.tf
@@ -68,6 +68,10 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
         name  = "ENABLE_MCP"
         value = var.enable_mcp ? "true" : "false"
       }
+      env {
+        name  = "DC_INSTRUCTIONS_DIR"
+        value = var.cdc_bucket_name != "" ? "gs://${var.cdc_bucket_name}/input/mcp_instructions" : ""
+      }
     }
 
     dynamic "vpc_access" {

--- a/infra/dcp/modules/cdc_services/main.tf
+++ b/infra/dcp/modules/cdc_services/main.tf
@@ -70,7 +70,7 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
       }
       env {
         name  = "DC_INSTRUCTIONS_DIR"
-        value = var.cdc_bucket_name != "" ? "gs://${var.cdc_bucket_name}/input/mcp_instructions" : ""
+        value = var.cdc_bucket_name != "" ? "gs://${var.cdc_bucket_name}/mcp_instructions" : ""
       }
     }
 

--- a/infra/dcp/modules/cdc_services/variables.tf
+++ b/infra/dcp/modules/cdc_services/variables.tf
@@ -82,3 +82,9 @@ variable "secret_env_vars" {
     version = string
   }))
 }
+
+variable "cdc_bucket_name" {
+  type        = string
+  description = "Name of the GCS bucket for CDC data"
+  default     = ""
+}

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -325,6 +325,7 @@ module "cdc_services" {
   google_analytics_tag_id           = var.cdc.google_analytics_tag_id
   dc_search_scope                   = var.cdc.search_scope
   enable_mcp                        = var.cdc.enable_mcp
+  cdc_bucket_name                   = module.storage.cdc_bucket_name
   service_account_email             = module.cdc_iam[0].service_account_email
   vpc_connector_id                  = module.cdc_network[0].connector_id
   use_spanner                       = local.cdc_use_spanner


### PR DESCRIPTION
Propagate the DC_INSTRUCTION_DIR to the CDC web Service for the MCP to pick it up. Was able to successfully test it by getting my Gemini CLI, connected to localhost MCP server (via gcloud proxy of my deployed MCP server) to show the custom instructions.

Note that my plan was to use the same GCS bucket where we tell them to upload their data. The users have the abiltity to come with their own GCS bucket if they would like. 