### PR TITLE
Updated CLI tooling to reflect new terraform output variable names

### DIFF
--- a/infra/dcp/modules/ingestion/helper_service/outputs.tf
+++ b/infra/dcp/modules/ingestion/helper_service/outputs.tf
@@ -1,4 +1,4 @@
-output "ingestion_helper_uri" {
+output "ingestion_helper_url" {
   value = var.deploy ? google_cloud_run_v2_service.ingestion_helper[0].uri : null
 }
 

--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -41,7 +41,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
           try:
             call: http.post
             args:
-              url: '${var.ingestion_helper_uri}'
+              url: '${var.ingestion_helper_url}'
               auth:
                 type: OIDC
               body:
@@ -62,7 +62,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
               - set_import_staging:
                   call: http.post
                   args:
-                    url: '${var.ingestion_helper_uri}'
+                    url: '${var.ingestion_helper_url}'
                     auth:
                       type: OIDC
                     body:
@@ -122,7 +122,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
               - trigger_bq_federation:
                   call: http.post
                   args:
-                    url: '${var.ingestion_helper_uri}'
+                    url: '${var.ingestion_helper_url}'
                     auth:
                       type: OIDC
                     body:
@@ -132,7 +132,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
               - promote_version:
                   call: http.post
                   args:
-                    url: '${var.ingestion_helper_uri}'
+                    url: '${var.ingestion_helper_url}'
                     auth:
                       type: OIDC
                     body:
@@ -144,7 +144,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
               - update_ingestion_history_step:
                   call: http.post
                   args:
-                    url: '${var.ingestion_helper_uri}'
+                    url: '${var.ingestion_helper_url}'
                     auth:
                       type: OIDC
                     body:
@@ -165,7 +165,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
       - release_lock_step:
           call: http.post
           args:
-            url: '${var.ingestion_helper_uri}'
+            url: '${var.ingestion_helper_url}'
             auth:
               type: OIDC
             body:

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -22,7 +22,7 @@ variable "lock_acquisition_timeout" {
   type = number
 }
 
-variable "ingestion_helper_uri" {
+variable "ingestion_helper_url" {
   type = string
 }
 

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -180,7 +180,7 @@ module "ingestion_workflow" {
   deletion_protection            = var.global.deletion_protection
   project_id                     = var.global.project_id
   lock_acquisition_timeout       = var.ingestion_config.workflow_lock_acquisition_timeout
-  ingestion_helper_uri           = module.ingestion_helper_service.ingestion_helper_uri
+  ingestion_helper_url           = module.ingestion_helper_service.ingestion_helper_url
   dataflow_service_account_email = module.ingestion_dataflow.service_account_email
   enable_bigquery_postprocessing = var.ingestion_config.workflow_enable_bigquery_postprocessing
   enable_datacommons_services    = var.datacommons_services_config.enable

--- a/infra/dcp/modules/stack/outputs.tf
+++ b/infra/dcp/modules/stack/outputs.tf
@@ -31,9 +31,9 @@ output "ingestion_workflow_name" {
   value       = module.ingestion_workflow.workflow_name
 }
 
-output "ingestion_service_uri" {
-  description = "URI of the ingestion support Cloud Run service"
-  value       = module.ingestion_helper_service.ingestion_helper_uri
+output "ingestion_service_url" {
+  description = "URL of the ingestion support Cloud Run service"
+  value       = module.ingestion_helper_service.ingestion_helper_url
 }
 
 output "ingestion_prep_job_name" {

--- a/infra/dcp/outputs.tf
+++ b/infra/dcp/outputs.tf
@@ -30,9 +30,9 @@ output "ingestion_workflow_name" {
   value       = module.stack.ingestion_workflow_name
 }
 
-output "ingestion_service_uri" {
-  description = "URI of the ingestion support Cloud Run service"
-  value       = module.stack.ingestion_service_uri
+output "ingestion_service_url" {
+  description = "URL of the ingestion support Cloud Run service"
+  value       = module.stack.ingestion_service_url
 }
 
 output "ingestion_prep_job_name" {

--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -478,31 +478,31 @@ def init(
 
 def _setup_ingestion_client() -> Tuple[Any, str, str]:
     click.secho(
-        "Fetching Ingestion Helper URI, Orchestrator Service Account, and Spanner details from Terraform outputs...",
+        "Fetching Ingestion Service URL, Workflow Service Account, and Spanner details from Terraform outputs...",
         fg="bright_black",
     )
 
     from datacommons_admin.tf_utils import (
-        get_dcp_ingestion_helper_uri,
-        get_dcp_orchestrator_service_account_email,
-        get_dcp_spanner_instance_id,
-        get_dcp_spanner_database_id,
+        get_ingestion_service_url,
+        get_ingestion_workflow_service_account_email,
+        get_spanner_instance_id,
+        get_spanner_database_id,
     )
     from datacommons_admin.ingestion_helper_client import IngestionHelperClient
 
-    uri = get_dcp_ingestion_helper_uri()
-    sa_email = get_dcp_orchestrator_service_account_email()
-    instance_id = get_dcp_spanner_instance_id()
-    database_id = get_dcp_spanner_database_id()
+    url = get_ingestion_service_url()
+    sa_email = get_ingestion_workflow_service_account_email()
+    instance_id = get_spanner_instance_id()
+    database_id = get_spanner_database_id()
 
-    click.secho(f"Found Ingestion Helper URI: {uri}", fg="green")
-    click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
+    click.secho(f"Found Ingestion Service URL: {url}", fg="green")
+    click.secho(f"Found Ingestion Workflow Service Account: {sa_email}", fg="green")
     click.secho(
         f"Found Spanner Database Instance: {instance_id} / Database ID: {database_id}",
         fg="green",
     )
 
-    client = IngestionHelperClient(uri, service_account_email=sa_email)
+    client = IngestionHelperClient(url, service_account_email=sa_email)
     return client, instance_id, database_id
 
 

--- a/packages/datacommons-admin/datacommons_admin/ingest_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/ingest_cli.py
@@ -17,11 +17,11 @@ import re
 
 from datacommons_admin.ingestion_job_client import IngestionJobClient
 from datacommons_admin.tf_utils import (
-    get_cdc_data_job_name,
-    get_dcp_orchestrator_service_account_email,
-    get_dcp_project_id,
-    get_dcp_region,
-    get_dcp_workflow_name,
+    get_ingestion_prep_job_name,
+    get_ingestion_workflow_service_account_email,
+    get_project_id,
+    get_region,
+    get_ingestion_workflow_name,
 )
 
 
@@ -35,18 +35,18 @@ def start() -> None:
     """Start a data ingestion job execution."""
     click.secho("Datacommons Admin Ingest Start", fg="cyan", bold=True)
     click.secho(
-        "Fetching Data Job Name and Orchestrator Service Account from Terraform outputs...",
+        "Fetching Data Job Name and Workflow Service Account from Terraform outputs...",
         fg="bright_black",
     )
 
-    job_name = get_cdc_data_job_name()
-    sa_email = get_dcp_orchestrator_service_account_email()
-    project_id = get_dcp_project_id()
-    region = get_dcp_region()
-    workflow_name = get_dcp_workflow_name()
+    job_name = get_ingestion_prep_job_name()
+    sa_email = get_ingestion_workflow_service_account_email()
+    project_id = get_project_id()
+    region = get_region()
+    workflow_name = get_ingestion_workflow_name()
 
     click.secho(f"Found Data Job Name: {job_name}", fg="green")
-    click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
+    click.secho(f"Found Workflow Service Account: {sa_email}", fg="green")
     click.secho(f"Found GCP Project ID: {project_id}", fg="green")
     click.secho(f"Found GCP Region: {region}", fg="green")
     click.secho(
@@ -100,17 +100,17 @@ def show_config() -> None:
     """Print the current ingestion job configuration (environment variables)."""
     click.secho("Datacommons Admin Ingest Show-Config", fg="cyan", bold=True)
     click.secho(
-        "Fetching Data Job Name and Orchestrator Service Account from Terraform outputs...",
+        "Fetching Data Job Name and Workflow Service Account from Terraform outputs...",
         fg="bright_black",
     )
 
-    job_name = get_cdc_data_job_name()
-    sa_email = get_dcp_orchestrator_service_account_email()
-    project_id = get_dcp_project_id()
-    region = get_dcp_region()
+    job_name = get_ingestion_prep_job_name()
+    sa_email = get_ingestion_workflow_service_account_email()
+    project_id = get_project_id()
+    region = get_region()
 
     click.secho(f"Found Data Job Name: {job_name}", fg="green")
-    click.secho(f"Found Orchestrator Service Account: {sa_email}", fg="green")
+    click.secho(f"Found Workflow Service Account: {sa_email}", fg="green")
     click.secho(f"Found GCP Project ID: {project_id}", fg="green")
     click.secho(f"Found GCP Region: {region}", fg="green")
     click.secho(

--- a/packages/datacommons-admin/datacommons_admin/tf_utils.py
+++ b/packages/datacommons-admin/datacommons_admin/tf_utils.py
@@ -19,14 +19,14 @@ import subprocess
 import click
 
 
-TF_OUTPUT_INGESTION_HELPER_URI = "dcp_ingestion_helper_uri"
-TF_OUTPUT_ORCHESTRATOR_SERVICE_ACCOUNT_EMAIL = "dcp_orchestrator_service_account_email"
-TF_OUTPUT_SPANNER_INSTANCE_ID = "dcp_spanner_instance_id"
-TF_OUTPUT_SPANNER_DATABASE_ID = "dcp_spanner_database_id"
-TF_OUTPUT_CDC_DATA_JOB_NAME = "cdc_data_job_name"
+TF_OUTPUT_INGESTION_SERVICE_URL = "ingestion_service_url"
+TF_OUTPUT_INGESTION_WORKFLOW_SERVICE_ACCOUNT_EMAIL = "ingestion_workflow_service_account_email"
+TF_OUTPUT_SPANNER_INSTANCE_ID = "spanner_instance_id"
+TF_OUTPUT_SPANNER_DATABASE_ID = "spanner_database_id"
+TF_OUTPUT_INGESTION_PREP_JOB_NAME = "ingestion_prep_job_name"
 TF_OUTPUT_PROJECT_ID = "project_id"
 TF_OUTPUT_REGION = "region"
-TF_OUTPUT_WORKFLOW_NAME = "workflow_name"
+TF_OUTPUT_INGESTION_WORKFLOW_NAME = "ingestion_workflow_name"
 
 
 def get_terraform_output(key: str) -> str:
@@ -94,41 +94,41 @@ def get_terraform_output(key: str) -> str:
     return str(value)
 
 
-def get_dcp_ingestion_helper_uri() -> str:
-    """Convenience wrapper to fetch the dcp_ingestion_helper_uri Terraform output."""
-    return get_terraform_output(TF_OUTPUT_INGESTION_HELPER_URI)
+def get_ingestion_service_url() -> str:
+    """Convenience wrapper to fetch the ingestion_service_url Terraform output."""
+    return get_terraform_output(TF_OUTPUT_INGESTION_SERVICE_URL)
 
 
-def get_dcp_orchestrator_service_account_email() -> str:
-    """Convenience wrapper to fetch the dcp_orchestrator_service_account_email Terraform output."""
-    return get_terraform_output(TF_OUTPUT_ORCHESTRATOR_SERVICE_ACCOUNT_EMAIL)
+def get_ingestion_workflow_service_account_email() -> str:
+    """Convenience wrapper to fetch the ingestion_workflow_service_account_email Terraform output."""
+    return get_terraform_output(TF_OUTPUT_INGESTION_WORKFLOW_SERVICE_ACCOUNT_EMAIL)
 
 
-def get_dcp_spanner_instance_id() -> str:
-    """Convenience wrapper to fetch the dcp_spanner_instance_id Terraform output."""
+def get_spanner_instance_id() -> str:
+    """Convenience wrapper to fetch the spanner_instance_id Terraform output."""
     return get_terraform_output(TF_OUTPUT_SPANNER_INSTANCE_ID)
 
 
-def get_dcp_spanner_database_id() -> str:
-    """Convenience wrapper to fetch the dcp_spanner_database_id Terraform output."""
+def get_spanner_database_id() -> str:
+    """Convenience wrapper to fetch the spanner_database_id Terraform output."""
     return get_terraform_output(TF_OUTPUT_SPANNER_DATABASE_ID)
 
 
-def get_cdc_data_job_name() -> str:
-    """Convenience wrapper to fetch the cdc_data_job_name Terraform output."""
-    return get_terraform_output(TF_OUTPUT_CDC_DATA_JOB_NAME)
+def get_ingestion_prep_job_name() -> str:
+    """Convenience wrapper to fetch the ingestion_prep_job_name Terraform output."""
+    return get_terraform_output(TF_OUTPUT_INGESTION_PREP_JOB_NAME)
 
 
-def get_dcp_project_id() -> str:
+def get_project_id() -> str:
     """Convenience wrapper to fetch the project_id Terraform output."""
     return get_terraform_output(TF_OUTPUT_PROJECT_ID)
 
 
-def get_dcp_region() -> str:
+def get_region() -> str:
     """Convenience wrapper to fetch the region Terraform output."""
     return get_terraform_output(TF_OUTPUT_REGION)
 
 
-def get_dcp_workflow_name() -> str:
-    """Convenience wrapper to fetch the workflow_name Terraform output."""
-    return get_terraform_output(TF_OUTPUT_WORKFLOW_NAME)
+def get_ingestion_workflow_name() -> str:
+    """Convenience wrapper to fetch the ingestion_workflow_name Terraform output."""
+    return get_terraform_output(TF_OUTPUT_INGESTION_WORKFLOW_NAME)

--- a/packages/datacommons-admin/datacommons_admin/tf_utils.py
+++ b/packages/datacommons-admin/datacommons_admin/tf_utils.py
@@ -20,7 +20,9 @@ import click
 
 
 TF_OUTPUT_INGESTION_SERVICE_URL = "ingestion_service_url"
-TF_OUTPUT_INGESTION_WORKFLOW_SERVICE_ACCOUNT_EMAIL = "ingestion_workflow_service_account_email"
+TF_OUTPUT_INGESTION_WORKFLOW_SERVICE_ACCOUNT_EMAIL = (
+    "ingestion_workflow_service_account_email"
+)
 TF_OUTPUT_SPANNER_INSTANCE_ID = "spanner_instance_id"
 TF_OUTPUT_SPANNER_DATABASE_ID = "spanner_database_id"
 TF_OUTPUT_INGESTION_PREP_JOB_NAME = "ingestion_prep_job_name"

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -201,7 +201,7 @@ def test_init_db_success(
     from unittest.mock import MagicMock
 
     mock_proc = MagicMock()
-    mock_proc.stdout = '{"dcp_ingestion_helper_uri": {"value": "https://mock-helper"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}, "dcp_spanner_instance_id": {"value": "mock-instance"}, "dcp_spanner_database_id": {"value": "mock-db"}}'
+    mock_proc.stdout = '{"ingestion_service_url": {"value": "https://mock-helper"}, "ingestion_workflow_service_account_email": {"value": "mock-orch-sa@mock.com"}, "spanner_instance_id": {"value": "mock-instance"}, "spanner_database_id": {"value": "mock-db"}}'
     mock_run.return_value = mock_proc
 
     mock_creds = MagicMock()
@@ -235,7 +235,7 @@ def test_init_db_init_only(
     from unittest.mock import MagicMock
 
     mock_proc = MagicMock()
-    mock_proc.stdout = '{"dcp_ingestion_helper_uri": {"value": "https://mock-helper"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}, "dcp_spanner_instance_id": {"value": "mock-instance"}, "dcp_spanner_database_id": {"value": "mock-db"}}'
+    mock_proc.stdout = '{"ingestion_service_url": {"value": "https://mock-helper"}, "ingestion_workflow_service_account_email": {"value": "mock-orch-sa@mock.com"}, "spanner_instance_id": {"value": "mock-instance"}, "spanner_database_id": {"value": "mock-db"}}'
     mock_run.return_value = mock_proc
 
     mock_creds = MagicMock()
@@ -269,7 +269,7 @@ def test_seed_db_success(
     from unittest.mock import MagicMock
 
     mock_proc = MagicMock()
-    mock_proc.stdout = '{"dcp_ingestion_helper_uri": {"value": "https://mock-helper"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}, "dcp_spanner_instance_id": {"value": "mock-instance"}, "dcp_spanner_database_id": {"value": "mock-db"}}'
+    mock_proc.stdout = '{"ingestion_service_url": {"value": "https://mock-helper"}, "ingestion_workflow_service_account_email": {"value": "mock-orch-sa@mock.com"}, "spanner_instance_id": {"value": "mock-instance"}, "spanner_database_id": {"value": "mock-db"}}'
     mock_run.return_value = mock_proc
 
     mock_creds = MagicMock()
@@ -302,7 +302,7 @@ def test_ingest_start_success(
     from unittest.mock import MagicMock
 
     mock_proc = MagicMock()
-    mock_proc.stdout = '{"cdc_data_job_name": {"value": "projects/mock-proj/locations/us-central1/jobs/mock-job"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}, "project_id": {"value": "mock-proj"}, "region": {"value": "us-central1"}, "workflow_name": {"value": "mock-workflow"}}'
+    mock_proc.stdout = '{"ingestion_prep_job_name": {"value": "projects/mock-proj/locations/us-central1/jobs/mock-job"}, "ingestion_workflow_service_account_email": {"value": "mock-orch-sa@mock.com"}, "project_id": {"value": "mock-proj"}, "region": {"value": "us-central1"}, "ingestion_workflow_name": {"value": "mock-workflow"}}'
     mock_run.return_value = mock_proc
 
     mock_creds = MagicMock()
@@ -346,7 +346,7 @@ def test_ingest_show_config_success(
     from unittest.mock import MagicMock
 
     mock_proc = MagicMock()
-    mock_proc.stdout = '{"cdc_data_job_name": {"value": "mock-job"}, "dcp_orchestrator_service_account_email": {"value": "mock-orch-sa@mock.com"}, "project_id": {"value": "mock-proj"}, "region": {"value": "us-central1"}}'
+    mock_proc.stdout = '{"ingestion_prep_job_name": {"value": "mock-job"}, "ingestion_workflow_service_account_email": {"value": "mock-orch-sa@mock.com"}, "project_id": {"value": "mock-proj"}, "region": {"value": "us-central1"}}'
     mock_run.return_value = mock_proc
 
     mock_creds = MagicMock()


### PR DESCRIPTION
This change resolves a Terraform compilation error and standardizes outputs from `uri` to `url` conventions across the infrastructure module and the python packages that consume the Terraform state.
#### Changes
1. Renamed `ingestion_service_uri` and `ingestion_helper_uri` to `ingestion_service_url` and `ingestion_helper_url` across all modules
2. Updated python module wrappers in `packages/datacommons-admin` to use the correct terraform output variables:
     - `dcp_ingestion_helper_uri` -> `ingestion_service_url`
     - `dcp_orchestrator_service_account_email` -> `ingestion_workflow_service_account_email`
     - `dcp_spanner_instance_id` -> `spanner_instance_id`
     - `dcp_spanner_database_id` -> `spanner_database_id`
     - `cdc_data_job_name` -> `ingestion_prep_job_name`
     - `workflow_name` -> `ingestion_workflow_name`
   - Updated the mock output structures in unit tests to pass CLI verification checks.