### PR TITLE
Revert "[DCP - Services] - Fix mixer startup probe to prevent downtime & remove exponential backoff on lock acquisition"

### DIFF
--- a/infra/dcp/modules/datacommons_services/main.tf
+++ b/infra/dcp/modules/datacommons_services/main.tf
@@ -45,11 +45,10 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
       }
 
       startup_probe {
-        timeout_seconds   = 29
+        timeout_seconds   = 120
         period_seconds    = 30
-        failure_threshold = 30 # 30 * 30s = 15 minutes
-        http_get {
-          path = "/health"
+        failure_threshold = 6
+        tcp_socket {
           port = 8080
         }
       }

--- a/infra/dcp/modules/datacommons_services/main.tf
+++ b/infra/dcp/modules/datacommons_services/main.tf
@@ -45,9 +45,9 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
       }
 
       startup_probe {
-        timeout_seconds   = 120
+        timeout_seconds   = 29
         period_seconds    = 30
-        failure_threshold = 6
+        failure_threshold = 6 # 15 minutes of waiting
         tcp_socket {
           port = 8080
         }

--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -51,10 +51,10 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
             result: lock_result
           retry:
             predicate: '$${http.default_retry_predicate}'
-            max_retries: 20
+            max_retries: 60 # Approx 5 hours
             backoff:
-              initial_delay: 300
-              max_delay: 600
+              initial_delay: 60
+              max_delay: 300 # Max 5 minutes retry interval
               multiplier: 2
       - process_ingestion:
           try:

--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -51,10 +51,10 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
             result: lock_result
           retry:
             predicate: '$${http.default_retry_predicate}'
-            max_retries: 60 # Approx 5 hours
+            max_retries: 20
             backoff:
-              initial_delay: 60
-              max_delay: 300 # Max 5 minutes retry interval
+              initial_delay: 300
+              max_delay: 600
               multiplier: 2
       - process_ingestion:
           try:


### PR DESCRIPTION
Reverts datacommonsorg/datacommons#75

This is just the short term fix to buy us a few months to find the right long term fix. It will allow the deployment to succeed even as mixer and MCP continue to fail to startup properly before the init-db command is run