### PR TITLE
[DCP - APIs] Disable destroy APIs

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -53,7 +53,15 @@ resource "google_project_service" "apis" {
   ] : []))
 
   service            = each.key
-  disable_on_destroy = false
+  disable_on_destroy = true
+}
+
+resource "time_sleep" "wait_for_foundation" {
+  create_duration = "90s"
+
+  depends_on = [
+    google_project_service.apis
+  ]
 }
 
 locals {

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -56,14 +56,6 @@ resource "google_project_service" "apis" {
   disable_on_destroy = true
 }
 
-resource "time_sleep" "wait_for_foundation" {
-  create_duration = "90s"
-
-  depends_on = [
-    google_project_service.apis
-  ]
-}
-
 locals {
   global_config = {
     project_id                    = var.project_id


### PR DESCRIPTION
This causes some issues for projects where we might create multiple instances. If you enable as part of tf setup #1, then deploy TF setup #2, then destroy #1, you would also break number 2. 

It sounds like it's normal for APIs to remain enabled. There is no cost for just enabling it.