### PR TITLE
Added datacommons-cli script

### DIFF
--- a/packages/datacommons-cli/pyproject.toml
+++ b/packages/datacommons-cli/pyproject.toml
@@ -16,6 +16,7 @@ urls = {Homepage = "https://github.com/datacommonsorg/datacommons"}
 
 [project.scripts]
 datacommons = "datacommons_cli.cli:cli"
+datacommons-cli = "datacommons_cli.cli:cli"
 
 [build-system]
 requires = ["uv", "setuptools"]


### PR DESCRIPTION
Currently, running the Data Commons CLI via `uvx` requires specifying the source package *and* executable name because the executable (`datacommons`) does not match the package name (`datacommons-cli`):

```
uvx --from datacommons-cli datacommons admin init
```

This PR adds  a matching `datacommons-cli` script entrypoint so uv can automatically infer the package, allowing for a shorter command:

```
uvx datacommons-cli admin init
```

We also retain the existing `datacommons` entrypoint. This ensures that users who install the package globally can still use the traditional `datacommons` command in their terminal.