### PR TITLE
Added datacommons-cli and datacommons-admin readmes

### DIFF
--- a/packages/datacommons-admin/README.md
+++ b/packages/datacommons-admin/README.md
@@ -1,3 +1,53 @@
-# datacommons-admin
+# Data Commons Admin Tooling
 
-This package provides the `admin` command group consumed by the top-level `datacommons` CLI for initializing and managing Data Commons platform instances in GCP.
+<p align="center">
+  <a href="https://www.datacommons.org"><img src="https://datacommons.org/images/dc-logo.svg" alt="Data Commons" width="120"></a>
+</p>
+
+<p align="center">
+  <em>The administrative and deployment tooling of the Data Commons Platform.</em>
+</p>
+
+---
+
+`datacommons-admin` provides administrative subcommands of the Data Commons Platform. It handles the heavy lifting for:
+- Scaffolding and configuring Terraform templates.
+- Provisioning GCP infrastructure (GCS Buckets, Spanner instance/databases).
+- Managing and seeding platform schemas and geographic datasets.
+- Directing background data ingestion pipelines on Cloud Run and Cloud Workflows.
+
+---
+
+> [!IMPORTANT]
+> ### Looking for the Command Line Tool?
+> This package is designed as a library module and is consumed by the main entrypoint CLI.
+> 
+> To execute administrative commands on your terminal, please download and install the main **[datacommons-cli](https://pypi.org/project/datacommons-cli/)** package:
+> 
+> ```bash
+> sudo pip install -H datacommons-cli
+> # Or using uv
+> uv tool install datacommons-cli
+> ```
+> Once installed, all administrative features from this package are exposed under:
+> ```bash
+> datacommons admin --help
+> ```
+>
+> Alternatively, run the admin CLI without installing it using uvx:
+> ```bash
+> uvx datacommons-cli admin --help
+> ```
+
+---
+
+## Links & Resources
+
+- **Core CLI Package**: [datacommons-cli on PyPI](https://pypi.org/project/datacommons-cli/)
+- **Source Code**: [datacommons-cli on GitHub](https://github.com/datacommonsorg/datacommons/tree/main/packages/datacommons-cli), [datacommons-admin on GitHub](https://github.com/datacommonsorg/datacommons/tree/main/packages/datacommons-admin)
+- **Official Website**: [datacommons.org](https://www.datacommons.org)
+- **Platform Documentation**: [docs.datacommons.org](https://docs.datacommons.org)
+
+---
+
+License: [Apache-2.0](https://github.com/datacommonsorg/datacommons/blob/main/LICENSE)

--- a/packages/datacommons-admin/README.md
+++ b/packages/datacommons-admin/README.md
@@ -25,7 +25,7 @@
 > To execute administrative commands on your terminal, please download and install the main **[datacommons-cli](https://pypi.org/project/datacommons-cli/)** package:
 > 
 > ```bash
-> sudo pip install -H datacommons-cli
+> pip install --user datacommons-cli
 > # Or using uv
 > uv tool install datacommons-cli
 > ```

--- a/packages/datacommons-cli/README.md
+++ b/packages/datacommons-cli/README.md
@@ -1,0 +1,99 @@
+# Data Commons CLI
+
+<p align="center">
+  <a href="https://www.datacommons.org"><img src="https://datacommons.org/images/dc-logo.svg" alt="Data Commons" width="120"></a>
+</p>
+
+<p align="center">
+  <em>Standard command-line interface for interacting with, deploying, and administering the Data Commons Platform.</em>
+</p>
+
+---
+
+[Data Commons](https://www.datacommons.org) is an open-source project initiated by Google that aggregates data from hundreds of public sources, such as the US Census, Eurostat, CDC, and UN, into a unified, standard Knowledge Graph.
+
+The **Data Commons Platform** provides the infrastructure to run your own private instance of Data Commons, allowing you to seamlessly combine public datasets with your own custom, private data using modern APIs, graph query engines, and visualization dashboards.
+
+---
+
+## Installation
+
+Install the Data Commons CLI using `pip` or `uv`:
+
+```bash
+sudo pip install -H datacommons-cli
+```
+
+For a global installation using `uv` (which manages your PATH automatically):
+
+```bash
+uv tool install datacommons-cli
+```
+
+Or execute it on-the-fly without installation using `uvx`:
+
+```bash
+uvx datacommons-cli --help
+```
+
+## Help & Documentation
+
+For full documentation, tutorials, and deployment guides, visit:
+👉 **[docs.datacommons.org](https://docs.datacommons.org)**
+
+---
+
+## Usage
+
+The CLI exposes standard operations under the main `datacommons` entrypoint. You can check the version and get help instantly:
+
+```bash
+# Show help menu
+datacommons --help
+
+# Show version
+datacommons --version
+```
+
+---
+
+## Administrative Commands
+
+All infrastructure setup, database operations, and ingestion pipelines are managed under the `admin` sub-command group:
+
+```bash
+datacommons admin [COMMAND] --help
+```
+
+### Available Commands
+
+| Command | Description |
+| --- | --- |
+| **`init`** | Scaffolds a localized Terraform configuration to deploy the Data Commons Platform on Google Cloud Platform (GCP). |
+| **`init-db`** | Configures database schemas and seeds baseline tables on GCP Spanner via the Ingestion Helper service. |
+| **`seed-db`** | Re-runs or updates base geographic and schema seeds on GCP Spanner. |
+| **`ingest start`** | Triggers a Cloud Run + Cloud Workflows background data ingestion pipeline to import your custom datasets. |
+| **`ingest show-config`**| Prints current background ingestion parameters, GCS bucket paths, and active GCP credentials. |
+
+### Quickstart: Scaffolding a Private Data Commons
+
+1. Initialize your project configuration and scaffold Terraform templates:
+   ```bash
+   datacommons admin init --project-id my-gcp-project --namespace prod
+   ```
+
+2. Change directories to the scaffolded directory (e.g. `cd prod`).
+
+3. Deploy using Terraform, then initialize and seed your Spanner database:
+   ```bash
+   datacommons admin init-db
+   ```
+
+4. Trigger your first background data ingestion pipeline:
+   ```bash
+   datacommons admin ingest start
+   ```
+
+---
+
+License: [Apache-2.0](https://github.com/datacommonsorg/datacommons/blob/main/LICENSE)

--- a/packages/datacommons-cli/README.md
+++ b/packages/datacommons-cli/README.md
@@ -20,17 +20,33 @@ The **Data Commons Platform** provides the infrastructure to run your own privat
 
 Install the Data Commons CLI using `pip` or `uv`:
 
+### Install with `pip`
+
 ```bash
-sudo pip install -H datacommons-cli
+pip install --user datacommons-cli
 ```
 
-For a global installation using `uv` (which manages your PATH automatically):
+If the datacommons command is not found after installing, add Python's user-binary directory to your PATH:
+
+```
+export PATH="$PATH:$(python3 -m site --user-base)/bin"
+```
+
+### Install with `uv`
 
 ```bash
 uv tool install datacommons-cli
 ```
 
-Or execute it on-the-fly without installation using `uvx`:
+If the `datacommons` command is not found after installing, add the appropriate directory to your PATH:
+
+```
+export PATH="~/.local/bin:$PATH"
+```
+
+### With `uvx`
+
+Or execute `datacommons-cli` on-the-fly without installation using `uvx`:
 
 ```bash
 uvx datacommons-cli --help


### PR DESCRIPTION
Added `README.md`s for the `datacommons-cli` and `datacommons-admin` packages. These documents will display on the PyPI package pages upon release, and provide instructions for installation and usage of the CLI tooling.