### PR TITLE
V2 resolve with spanner embeddings

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -77,6 +77,7 @@ locals {
     processing_units                   = var.spanner_processing_units
     enable_bigquery_connection         = var.spanner_enable_bigquery_connection
     enable_embeddings_generation       = var.spanner_enable_embeddings_generation
+    resolve_with_spanner_embeddings    = var.spanner_resolve_with_spanner_embeddings
     bigquery_connection_name           = var.spanner_bigquery_connection_name
     create_bigquery_reservation        = var.spanner_create_bigquery_reservation
     bigquery_reservation_slot_capacity = var.spanner_bigquery_reservation_slot_capacity

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -97,7 +97,7 @@ locals {
     instructions_path               = var.datacommons_services_mcp_instructions_path != null ? trimsuffix(var.datacommons_services_mcp_instructions_path, "/") : null
     allow_unauthenticated_access    = var.datacommons_services_allow_unauthenticated_access
     website_disable_google_maps_api = var.datacommons_services_website_disable_google_maps_api
-    resolve_with_spanner_embeddings = var.spanner_resolve_with_spanner_embeddings
+    resolve_with_spanner_embeddings = var.datacommons_services_resolve_with_spanner_embeddings
   }
 
   auth_config = {

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -77,7 +77,6 @@ locals {
     processing_units                   = var.spanner_processing_units
     enable_bigquery_connection         = var.spanner_enable_bigquery_connection
     enable_embeddings_generation       = var.spanner_enable_embeddings_generation
-    resolve_with_spanner_embeddings    = var.spanner_resolve_with_spanner_embeddings
     bigquery_connection_name           = var.spanner_bigquery_connection_name
     create_bigquery_reservation        = var.spanner_create_bigquery_reservation
     bigquery_reservation_slot_capacity = var.spanner_bigquery_reservation_slot_capacity
@@ -98,6 +97,7 @@ locals {
     instructions_path               = var.datacommons_services_mcp_instructions_path != null ? trimsuffix(var.datacommons_services_mcp_instructions_path, "/") : null
     allow_unauthenticated_access    = var.datacommons_services_allow_unauthenticated_access
     website_disable_google_maps_api = var.datacommons_services_website_disable_google_maps_api
+    resolve_with_spanner_embeddings = var.spanner_resolve_with_spanner_embeddings
   }
 
   auth_config = {

--- a/infra/dcp/modules/datacommons_services/main.tf
+++ b/infra/dcp/modules/datacommons_services/main.tf
@@ -96,7 +96,7 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
         value = var.mcp_instructions_path != null ? "gs://${var.artifacts_bucket_name}/${var.mcp_instructions_path}" : ""
       }
       env {
-        name  = "ENABLE_SPANNER_SEARCH_BACKEND"
+        name  = "RESOLVE_WITH_SPANNER_EMBEDDINGS"
         value = var.resolve_with_spanner_embeddings ? "true" : "false"
       }
     }

--- a/infra/dcp/modules/datacommons_services/main.tf
+++ b/infra/dcp/modules/datacommons_services/main.tf
@@ -95,6 +95,10 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
         name  = "DC_INSTRUCTIONS_DIR"
         value = var.mcp_instructions_path != null ? "gs://${var.artifacts_bucket_name}/${var.mcp_instructions_path}" : ""
       }
+      env {
+        name  = "ENABLE_SPANNER_SEARCH_BACKEND"
+        value = var.resolve_with_spanner_embeddings ? "true" : "false"
+      }
     }
 
     dynamic "vpc_access" {

--- a/infra/dcp/modules/datacommons_services/variables.tf
+++ b/infra/dcp/modules/datacommons_services/variables.tf
@@ -67,6 +67,10 @@ variable "mcp_instructions_path" {
   default     = null
 }
 
+variable "resolve_with_spanner_embeddings" {
+  type    = bool
+}
+
 # =============================================================================
 # Infrastructure References
 # =============================================================================

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -65,7 +65,7 @@ locals {
     },
     {
       name  = "RESOLVE_WITH_SPANNER_EMBEDDINGS"
-      value = var.spanner_config.resolve_with_spanner_embeddings ? "true" : "false"
+      value = (var.spanner_config.enable && var.spanner_config.resolve_with_spanner_embeddings) ? "true" : "false"
     }
   ]
 

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -62,6 +62,10 @@ locals {
     {
       name  = "USE_SPANNER_GRAPH"
       value = "true"
+    },
+    {
+      name  = "RESOLVE_WITH_SPANNER_EMBEDDINGS"
+      value = var.spanner_config.resolve_with_spanner_embeddings ? "true" : "false"
     }
   ]
 

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -62,11 +62,7 @@ locals {
     {
       name  = "USE_SPANNER_GRAPH"
       value = "true"
-    },
-    {
-      name  = "RESOLVE_WITH_SPANNER_EMBEDDINGS"
-      value = (var.spanner_config.enable && var.spanner_config.resolve_with_spanner_embeddings) ? "true" : "false"
-    }
+    } 
   ]
 
   datacommons_services_secrets = var.datacommons_services_config.enable ? concat([
@@ -257,6 +253,7 @@ module "datacommons_services" {
   use_spanner             = var.spanner_config.enable
   env_vars                = local.cloud_run_shared_env_variables
   secret_env_vars         = local.datacommons_services_secrets
+  resolve_with_spanner_embeddings = var.datacommons_services_config.resolve_with_spanner_embeddings
 
   depends_on = [module.ingestion_preprocessing_job]
 }

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -62,7 +62,7 @@ locals {
     {
       name  = "USE_SPANNER_GRAPH"
       value = "true"
-    } 
+    }
   ]
 
   datacommons_services_secrets = var.datacommons_services_config.enable ? concat([

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -28,6 +28,7 @@ variable "spanner_config" {
     processing_units                   = number
     enable_bigquery_connection         = bool
     enable_embeddings_generation       = bool
+    resolve_with_spanner_embeddings    = bool
     bigquery_connection_name           = string
     create_bigquery_reservation        = bool
     bigquery_reservation_slot_capacity = number

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -28,7 +28,6 @@ variable "spanner_config" {
     processing_units                   = number
     enable_bigquery_connection         = bool
     enable_embeddings_generation       = bool
-    resolve_with_spanner_embeddings    = bool
     bigquery_connection_name           = string
     create_bigquery_reservation        = bool
     bigquery_reservation_slot_capacity = number
@@ -51,6 +50,7 @@ variable "datacommons_services_config" {
     instructions_path               = string
     allow_unauthenticated_access    = bool
     website_disable_google_maps_api = bool
+    resolve_with_spanner_embeddings = bool
   })
 }
 

--- a/infra/dcp/terraform.tfvars.template
+++ b/infra/dcp/terraform.tfvars.template
@@ -44,6 +44,7 @@ auth_google_datacommons_api_key = "$$DC_API_KEY$$"
 # Datacommons Services Module
 # =============================================================================
 # datacommons_services_allow_unauthenticated_access = true
+# datacommons_services_resolve_with_spanner_embeddings = true
 
 # =============================================================================
 # Ingestion - Preprocessing Job

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -197,6 +197,12 @@ variable "spanner_enable_embeddings_generation" {
   default     = true
 }
 
+variable "spanner_resolve_with_spanner_embeddings" {
+  description = "Enable resolving search queries with Spanner embeddings"
+  type        = bool
+  default     = true
+}
+
 variable "spanner_bigquery_connection_name" {
   description = "The name of the BigQuery external connection to Spanner"
   type        = string

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -306,7 +306,7 @@ variable "datacommons_services_mcp_instructions_path" {
 variable "datacommons_services_resolve_with_spanner_embeddings" {
   description = "Enable resolving search queries with Spanner embeddings"
   type        = bool
-  default     = true
+  default     = false
 }
 
 # =============================================================================

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -240,7 +240,7 @@ variable "enable_datacommons_services" {
 variable "datacommons_services_image" {
   description = "Docker image URL for the main Data Commons services"
   type        = string
-  default     = "gcr.io/datcom-ci/datacommons-services:latest"
+  default     = "gcr.io/datcom-ci/datacommons-services:xiaotest"
 }
 
 variable "datacommons_services_name" {

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -197,11 +197,6 @@ variable "spanner_enable_embeddings_generation" {
   default     = true
 }
 
-variable "spanner_resolve_with_spanner_embeddings" {
-  description = "Enable resolving search queries with Spanner embeddings"
-  type        = bool
-  default     = true
-}
 
 variable "spanner_bigquery_connection_name" {
   description = "The name of the BigQuery external connection to Spanner"
@@ -307,6 +302,12 @@ variable "datacommons_services_mcp_instructions_path" {
   description = "Directory path for customized instructions for server tools and agents"
   type        = string
   default     = null
+}
+
+variable "datacommons_services_resolve_with_spanner_embeddings" {
+  description = "Enable resolving search queries with Spanner embeddings"
+  type        = bool
+  default     = true
 }
 
 # =============================================================================

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -240,7 +240,7 @@ variable "enable_datacommons_services" {
 variable "datacommons_services_image" {
   description = "Docker image URL for the main Data Commons services"
   type        = string
-  default     = "gcr.io/datcom-ci/datacommons-services:xiaotest"
+  default     = "gcr.io/datcom-ci/datacommons-services:latest"
 }
 
 variable "datacommons_services_name" {

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -197,7 +197,6 @@ variable "spanner_enable_embeddings_generation" {
   default     = true
 }
 
-
 variable "spanner_bigquery_connection_name" {
   description = "The name of the BigQuery external connection to Spanner"
   type        = string


### PR DESCRIPTION
This PR create a variable to be sent to service as env variable

with the env variable set to true, we will read mixer custom.yaml (this is DCP specific YAML, do not use for CDC)
for mixer feature flag, and have below impact:
resolver will be able to resolve on spanner from v2/handler,
resolve on spanner embedding is enabled in the core function.
resolve on nl embedding is disabled in the core function.