### PR TITLE
change default platform images and package versions to 1.0.0

### DIFF
--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -234,7 +234,7 @@ variable "enable_datacommons_services" {
 variable "datacommons_services_image" {
   description = "Docker image URL for the main Data Commons services"
   type        = string
-  default     = "gcr.io/datcom-ci/datacommons-services:latest"
+  default     = "gcr.io/datcom-ci/datacommons-services:1.0.0"
 }
 
 variable "datacommons_services_name" {
@@ -310,7 +310,7 @@ variable "datacommons_services_mcp_instructions_path" {
 variable "ingestion_preprocessing_job_image" {
   description = "Docker image URL for the data ingestion pre-processing job"
   type        = string
-  default     = "gcr.io/datcom-ci/datacommons-data:latest"
+  default     = "gcr.io/datcom-ci/datacommons-data:1.0.0"
 }
 
 variable "ingestion_preprocessing_job_cpu" {
@@ -372,5 +372,5 @@ variable "ingestion_artifacts_path" {
 variable "ingestion_helper_service_image" {
   description = "Docker image URL for the ingestion support service"
   type        = string
-  default     = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
+  default     = "gcr.io/datcom-ci/datacommons-ingestion-helper:1.0.0"
 }


### PR DESCRIPTION
* [datacommons-services](https://pantheon.corp.google.com/artifacts/docker/datcom-ci/us/gcr.io/datacommons-services/sha256:287a350972ce63b3d61a7715aaa5ce46117974b072170ab5e5b337a625a9b36a?e=13803378&mods=-monitoring_api_staging&project=datcom-ci)
* [datacommons-data](https://pantheon.corp.google.com/artifacts/docker/datcom-ci/us/gcr.io/datacommons-data/sha256:d6872d7487a299caf6ef9f77db1c8c8c8937849ae86e6c9f0931b77a11cae592?e=13803378&mods=-monitoring_api_staging&project=datcom-ci)
* [ingestion helper](https://pantheon.corp.google.com/artifacts/docker/datcom-ci/us/gcr.io/datacommons-ingestion-helper/sha256:e37e25fe2dc571b7e60c22cc265ff2b53f14a5f9c7bb8ee790acead04da80b61?e=13803378&mods=-monitoring_api_staging&project=datcom-ci)

will update `pyproject.toml` in follow up. (should i run `./bin/terraform apply` immediately?)