### PR TITLE
update workflow and admin client to use RESTful ingestion-helper endpoints

### DIFF
--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -52,11 +52,10 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
           try:
             call: http.post
             args:
-              url: '${var.ingestion_helper_url}'
+              url: '${var.ingestion_helper_url}/database/lock/acquire'
               auth:
                 type: OIDC
               body:
-                actionType: "acquire_ingestion_lock"
                 workflowId: '$${workflow_id}'
                 timeout: '$${lock_timeout}'
             result: lock_result
@@ -73,11 +72,10 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
               - set_import_staging:
                   call: http.post
                   args:
-                    url: '${var.ingestion_helper_url}'
+                    url: '${var.ingestion_helper_url}/imports/status'
                     auth:
                       type: OIDC
                     body:
-                      actionType: "update_import_status"
                       importName: '$${input.importName}'
                       status: "STAGING"
                       latestVersion: '$${latest_version_gcs_path}'
@@ -137,11 +135,10 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
                             - run_postprocessings:
                                 call: http.post
                                 args:
-                                  url: '${var.ingestion_helper_url}'
+                                  url: '${var.ingestion_helper_url}/aggregation/run'
                                   auth:
                                     type: OIDC
                                   body:
-                                    actionType: "run_aggregation"
                                     importList: '$${json.decode(input.importList)}'
                                 result: postprocessing_result
                             - end_postproc_branch:
@@ -157,12 +154,11 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
                             - run_embeddings:
                                 call: http.post
                                 args:
-                                  url: '${var.ingestion_helper_url}'
+                                  url: '${var.ingestion_helper_url}/embeddings/ingest'
                                   auth:
                                     type: OIDC
                                   body:
-                                    actionType: "embedding_ingestion"
-                                    importList: '$${json.decode(input.importList)}'
+                                    enableEmbeddings: true
                                   timeout: ${var.embeddings_timeout}
                                 result: embedding_result
                             - end_embeddings_branch:
@@ -171,11 +167,10 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
               - promote_version:
                   call: http.post
                   args:
-                    url: '${var.ingestion_helper_url}'
+                    url: '${var.ingestion_helper_url}/imports/version'
                     auth:
                       type: OIDC
                     body:
-                      actionType: "update_import_version"
                       importName: '$${input.importName}'
                       version: '$${version}'
                       comment: '$${"Auto-promoted by workflow " + workflow_id}'
@@ -183,17 +178,15 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
               - update_ingestion_history_step:
                   call: http.post
                   args:
-                    url: '${var.ingestion_helper_url}'
+                    url: '${var.ingestion_helper_url}/imports/ingestion-status'
                     auth:
                       type: OIDC
                     body:
-                      actionType: "update_ingestion_status"
                       workflowId: '$${workflow_id}'
                       jobId: '$${job_id}'
                       status: 'SUCCESS'
                       importList:
                         - importName: '$${input.importName}'
-                          latestVersion: '$${version}'
                   result: history_result
           except:
             as: e
@@ -204,11 +197,10 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
       - release_lock_step:
           call: http.post
           args:
-            url: '${var.ingestion_helper_url}'
+            url: '${var.ingestion_helper_url}/database/lock/release'
             auth:
               type: OIDC
             body:
-              actionType: "release_ingestion_lock"
               workflowId: '$${workflow_id}'
           result: release_lock_result
       - fail_workflow:
@@ -229,11 +221,9 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
       - clear_cache_step:
           call: http.post
           args:
-            url: '${var.ingestion_helper_url}'
+            url: '${var.ingestion_helper_url}/cache/clear'
             auth:
               type: OIDC
-            body:
-              actionType: "clear_redis_cache"
           result: clear_cache_result
 %{endif}
 %{endif}

--- a/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
+++ b/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
@@ -18,10 +18,6 @@ from google.auth.transport.requests import AuthorizedSession, Request
 from google.oauth2 import id_token
 
 
-ACTION_INITIALIZE_DATABASE = "initialize_database"
-ACTION_SEED_DATABASE = "seed_database"
-
-
 class IngestionHelperClient:
     """Client for interacting with the DCP Ingestion Helper Cloud Run service."""
 
@@ -59,9 +55,8 @@ class IngestionHelperClient:
 
         self.session = AuthorizedSession(creds)
 
-    def _call_endpoint(self, action_type: str) -> dict:
-        url = self.base_url
-        payload = {"actionType": action_type}
+    def _call_endpoint(self, path: str, payload: dict = None) -> dict:
+        url = f"{self.base_url}/{path.lstrip('/')}"
 
         try:
             response = self.session.post(url, json=payload, timeout=300)
@@ -84,6 +79,7 @@ class IngestionHelperClient:
                 error_data = response.json()
                 error_msg = (
                     error_data.get("message")
+                    or error_data.get("detail")
                     or error_data.get("error")
                     or response.text
                 )
@@ -101,8 +97,8 @@ class IngestionHelperClient:
 
     def initialize_database(self) -> dict:
         """Calls the initialize_database endpoint on the ingestion helper service."""
-        return self._call_endpoint(ACTION_INITIALIZE_DATABASE)
+        return self._call_endpoint("database/initialize")
 
     def seed_database(self) -> dict:
         """Calls the seed_database endpoint on the ingestion helper service."""
-        return self._call_endpoint(ACTION_SEED_DATABASE)
+        return self._call_endpoint("database/seed")

--- a/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
+++ b/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
@@ -77,12 +77,19 @@ class IngestionHelperClient:
         if not response.ok:
             try:
                 error_data = response.json()
-                error_msg = (
-                    error_data.get("message")
-                    or error_data.get("detail")
-                    or error_data.get("error")
-                    or response.text
-                )
+                detail = error_data.get('detail')
+                if isinstance(detail, list):
+                    error_msg = ', '.join([
+                        f"{'.'.join(str(loc) for loc in err.get('loc', []))}: {err.get('msg')}"
+                        for err in detail if isinstance(err, dict)
+                    ]) or str(detail)
+                else:
+                    error_msg = (
+                        error_data.get('message')
+                        or (str(detail) if detail is not None else None)
+                        or error_data.get('error')
+                        or response.text
+                    )
             except Exception:
                 error_msg = response.text
 

--- a/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
+++ b/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py
@@ -77,17 +77,20 @@ class IngestionHelperClient:
         if not response.ok:
             try:
                 error_data = response.json()
-                detail = error_data.get('detail')
+                detail = error_data.get("detail")
                 if isinstance(detail, list):
-                    error_msg = ', '.join([
-                        f"{'.'.join(str(loc) for loc in err.get('loc', []))}: {err.get('msg')}"
-                        for err in detail if isinstance(err, dict)
-                    ]) or str(detail)
+                    error_msg = ", ".join(
+                        [
+                            f"{'.'.join(str(loc) for loc in err.get('loc', []))}: {err.get('msg')}"
+                            for err in detail
+                            if isinstance(err, dict)
+                        ]
+                    ) or str(detail)
                 else:
                     error_msg = (
-                        error_data.get('message')
+                        error_data.get("message")
                         or (str(detail) if detail is not None else None)
-                        or error_data.get('error')
+                        or error_data.get("error")
                         or response.text
                     )
             except Exception:


### PR DESCRIPTION
## Description
Updates the Spanner ingestion orchestration workflow and the administrative Python client to align with the new RESTful FastAPI endpoints introduced in the updated `ingestion-helper` service.

## Changes
* **Orchestration Workflow ([main.tf](file:///Users/dwnoble/Projects/datacommons/datacommons/infra/dcp/modules/ingestion/workflow/main.tf))**: Refactored HTTP POST steps to call specific RESTful endpoints (e.g., `/database/lock/acquire`, `/imports/status`, `/aggregation/run`, etc.) and removed the legacy `actionType` request body parameter.
* **Admin Client ([ingestion_helper_client.py](file:///Users/dwnoble/Projects/datacommons/datacommons/packages/datacommons-admin/datacommons_admin/ingestion_helper_client.py))**: Refactored `IngestionHelperClient` to call `/database/initialize` and `/database/seed` directly and updated error response parsing to handle standard FastAPI `detail` payloads.

## Coordinated Merge Required
This PR is paired with the helper service changes in [datacommonsorg/import#526](https://github.com/datacommonsorg/import/pull/526/). **Both PRs must be merged at the same time** to avoid breaking the ingestion pipeline and administrative database setup commands.
