### PR TITLE
chore: pin helper service module default image to 1.0.0

### DIFF
--- a/infra/dcp/modules/ingestion/helper_service/variables.tf
+++ b/infra/dcp/modules/ingestion/helper_service/variables.tf
@@ -33,7 +33,7 @@ variable "ingestion_bucket_name" {
 
 variable "image" {
   type    = string
-  default = "gcr.io/datcom-ci/datacommons-ingestion-helper:latest"
+  default = "gcr.io/datcom-ci/datacommons-ingestion-helper:1.0.0"
 }
 
 variable "bigquery_connection_id" {


### PR DESCRIPTION
This was missed from https://github.com/datacommonsorg/datacommons/pull/106 