### PR TITLE
feat(ingestion): expose Dataflow IP configuration for restricted VPC environments

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -136,6 +136,10 @@ locals {
     # Workflow & Helper Service
     workflow_lock_acquisition_timeout = var.ingestion_workflow_lock_acquisition_timeout
     helper_service_image              = var.ingestion_helper_service_image
+
+    # Dataflow Network Configuration
+    dataflow_ip_configuration = var.ingestion_dataflow_ip_configuration
+    dataflow_subnetwork       = var.ingestion_dataflow_subnetwork
   }
 }
 

--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -94,6 +94,12 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
                           serviceAccountEmail: '${var.dataflow_service_account_email}'
                           tempLocation: '$${input.tempLocation}'
                           stagingLocation: '$${input.tempLocation}'
+%{if var.dataflow_ip_configuration != "WORKER_IP_UNSPECIFIED"}
+                          ipConfiguration: '${var.dataflow_ip_configuration}'
+%{endif}
+%{if var.dataflow_subnetwork != ""}
+                          subnetwork: '${var.dataflow_subnetwork}'
+%{endif}
                   result: launch_result
               - get_job_id:
                   assign:

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -69,3 +69,29 @@ variable "ingestion_artifacts_path" {
   type        = string
   description = "Path where pre-processed files are placed for the next stage"
 }
+
+variable "dataflow_ip_configuration" {
+  type        = string
+  description = <<-EOT
+    IP configuration for Dataflow workers. Set to WORKER_IP_PRIVATE for
+    environments where an org policy (compute.vmExternalIpAccess) restricts
+    VMs from obtaining external IPs. Requires Private Google Access and
+    Cloud NAT on the target subnet.
+    Valid values: WORKER_IP_UNSPECIFIED, WORKER_IP_PUBLIC, WORKER_IP_PRIVATE.
+    See: https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.locations.flexTemplates/launch#FlexTemplateRuntimeEnvironment
+  EOT
+  default     = "WORKER_IP_UNSPECIFIED"
+  validation {
+    condition     = contains(["WORKER_IP_UNSPECIFIED", "WORKER_IP_PUBLIC", "WORKER_IP_PRIVATE"], var.dataflow_ip_configuration)
+    error_message = "Must be one of: WORKER_IP_UNSPECIFIED, WORKER_IP_PUBLIC, WORKER_IP_PRIVATE."
+  }
+}
+
+variable "dataflow_subnetwork" {
+  type        = string
+  description = <<-EOT
+    Subnetwork for Dataflow workers. Required when dataflow_ip_configuration
+    is WORKER_IP_PRIVATE. Format: regions/{region}/subnetworks/{subnetwork}.
+  EOT
+  default     = ""
+}

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -94,4 +94,16 @@ variable "dataflow_subnetwork" {
     is WORKER_IP_PRIVATE. Format: regions/{region}/subnetworks/{subnetwork}.
   EOT
   default     = ""
+
+  validation {
+    condition     = var.dataflow_subnetwork == "" || can(regex("regions/[a-zA-Z0-9-]+/subnetworks/[a-zA-Z0-9-]+$", var.dataflow_subnetwork))
+    error_message = "dataflow_subnetwork must be in the format 'regions/{region}/subnetworks/{subnetwork}' or a full self-link ending with that format."
+  }
+}
+
+check "dataflow_private_ip_requires_subnetwork" {
+  assert {
+    condition     = var.dataflow_ip_configuration != "WORKER_IP_PRIVATE" || var.dataflow_subnetwork != ""
+    error_message = "dataflow_subnetwork must be specified when dataflow_ip_configuration is WORKER_IP_PRIVATE."
+  }
 }

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -197,6 +197,8 @@ module "ingestion_workflow" {
   ingestion_helper_service_name  = "${var.global.namespace != "" ? "${var.global.namespace}-" : ""}dc-ingestion-helper"
   enable_redis_cache_clearing    = var.redis_config.enable
   ingestion_artifacts_path       = "${var.ingestion_config.ingestion_artifacts_path}/metadata"
+  dataflow_ip_configuration      = var.ingestion_config.dataflow_ip_configuration
+  dataflow_subnetwork            = var.ingestion_config.dataflow_subnetwork
 
   depends_on = [module.ingestion_helper_service]
 }

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -98,5 +98,11 @@ variable "ingestion_config" {
     # Workflow & Helper Service
     workflow_lock_acquisition_timeout = number
     helper_service_image              = string
+
+    # Dataflow network configuration
+    # Use WORKER_IP_PRIVATE when a compute.vmExternalIpAccess org policy
+    # blocks Dataflow workers from obtaining external IPs.
+    dataflow_ip_configuration = optional(string, "WORKER_IP_UNSPECIFIED")
+    dataflow_subnetwork       = optional(string, "")
   })
 }

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -380,3 +380,19 @@ variable "ingestion_helper_service_image" {
   type        = string
   default     = "gcr.io/datcom-ci/datacommons-ingestion-helper:1.0.0"
 }
+
+# =============================================================================
+# Ingestion - Dataflow Network Configuration
+# =============================================================================
+
+variable "ingestion_dataflow_ip_configuration" {
+  description = "IP configuration for Dataflow workers (WORKER_IP_UNSPECIFIED, WORKER_IP_PUBLIC, WORKER_IP_PRIVATE). Set to WORKER_IP_PRIVATE when a compute.vmExternalIpAccess org policy restricts VMs from obtaining external IPs."
+  type        = string
+  default     = "WORKER_IP_UNSPECIFIED"
+}
+
+variable "ingestion_dataflow_subnetwork" {
+  description = "Subnetwork for Dataflow workers. Required when ingestion_dataflow_ip_configuration is WORKER_IP_PRIVATE. Format: regions/{region}/subnetworks/{subnetwork}."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Adds two optional variables to the ingestion workflow module that allow operators
to configure Dataflow worker IP addressing:

- \`dataflow_ip_configuration\` — enum: \`WORKER_IP_UNSPECIFIED\` (default), \`WORKER_IP_PUBLIC\`,
  \`WORKER_IP_PRIVATE\`
- \`dataflow_subnetwork\` — subnetwork self-link, required when using \`WORKER_IP_PRIVATE\`

Both default to their current implicit values, so **existing deployments are unaffected**.

## Motivation

Enterprise and public-sector GCP organizations frequently enforce the
\`compute.vmExternalIpAccess\` org policy, which prevents any VM (including Dataflow
workers) from obtaining an external IP address. Without this change, the Dataflow Flex
Template launch fails immediately with an org policy violation and the job never leaves
\`JOB_STATE_PENDING\`.

The fix is to pass \`ipConfiguration: WORKER_IP_PRIVATE\` in the Dataflow
\`FlexTemplateRuntimeEnvironment\`. The module currently hardcodes this block inside the
Cloud Workflow \`source_contents\` YAML string with no way to inject it at the module level.

## Changes

| File | Change |
|------|--------|
| \`infra/dcp/variables.tf\` | Add top-level \`ingestion_dataflow_ip_configuration\` + \`ingestion_dataflow_subnetwork\` variables |
| \`infra/dcp/main.tf\` | Wire both variables into \`local.ingestion_config\` |
| \`infra/dcp/modules/ingestion/workflow/variables.tf\` | Add \`dataflow_ip_configuration\` + \`dataflow_subnetwork\` variables, format validation, and cross-variable \`check\` block |
| \`infra/dcp/modules/ingestion/workflow/main.tf\` | Conditionally emit \`ipConfiguration\` and \`subnetwork\` in the Dataflow environment block |
| \`infra/dcp/modules/stack/variables.tf\` | Add both fields as optional to the \`ingestion_config\` object |
| \`infra/dcp/modules/stack/main.tf\` | Pass both variables through to \`module.ingestion_workflow\` |

## Usage example

```hcl
# terraform.tfvars
ingestion_dataflow_ip_configuration = "WORKER_IP_PRIVATE"
ingestion_dataflow_subnetwork       = "regions/us-central1/subnetworks/default"
```

Prerequisites on the operator side:
- Private Google Access enabled on the target subnet
- Cloud NAT gateway attached to the subnet's Cloud Router

## Validation

Tested on a GCP project with an enforced \`compute.vmExternalIpAccess: deny\` org policy.
Ingestion of 66 SDMX/CSV observation files into Spanner completed successfully
(\`JOB_STATE_DONE\`). Without \`WORKER_IP_PRIVATE\` the job never left the \`JOB_STATE_PENDING\`
state.

## References

- Dataflow \`FlexTemplateRuntimeEnvironment.ipConfiguration\`:
  https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.locations.flexTemplates/launch#FlexTemplateRuntimeEnvironment
- \`compute.vmExternalIpAccess\` org policy:
  https://cloud.google.com/resource-manager/docs/organization-policy/restricting-resources