### PR TITLE
Enforce 16-character limit for namespace in CLI

### DIFF
--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -229,6 +229,16 @@ def admin() -> None:
     """Manage a Data Commons Platform instance in Google Cloud"""
 
 
+def _validate_namespace(ns: str) -> Tuple[bool, str]:
+    if not ns:
+        return False, "Namespace must not be empty."
+    if len(ns) > 16:
+        return False, f"Namespace must be 16 characters or less (currently {len(ns)} characters)."
+    if not re.match(r"^[a-z]([-a-z0-9]*[a-z0-9])?$", ns):
+        return False, "Namespace must start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase alphanumeric characters and dashes."
+    return True, ""
+
+
 def _resolve_project_config(
     project_id: str, namespace: str, force: bool
 ) -> Tuple[str, str, Path]:
@@ -247,23 +257,17 @@ def _resolve_project_config(
         raise click.ClickException("GCP project ID must not be empty.")
 
     resolved_namespace = namespace.strip()
-    if resolved_namespace and len(resolved_namespace) > 16:
-        raise click.ClickException(
-            f"Namespace '{resolved_namespace}' is too long ({len(resolved_namespace)} characters). "
-            "It must be 16 characters or less to comply with Google Cloud Service Account ID limits."
-        )
+    if resolved_namespace:
+        is_valid, err_msg = _validate_namespace(resolved_namespace)
+        if not is_valid:
+            raise click.ClickException(err_msg)
 
     while True:
         if not resolved_namespace:
             resolved_namespace = _prompt("Namespace", type=str).strip()
-            if not resolved_namespace:
-                click.secho("Error: Namespace must not be empty.", fg="red")
-                continue
-            if len(resolved_namespace) > 16:
-                click.secho(
-                    f"Error: Namespace must be 16 characters or less (currently {len(resolved_namespace)} characters).",
-                    fg="red",
-                )
+            is_valid, err_msg = _validate_namespace(resolved_namespace)
+            if not is_valid:
+                click.secho(f"Error: {err_msg}", fg="red")
                 resolved_namespace = ""
                 continue
 

--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -247,11 +247,24 @@ def _resolve_project_config(
         raise click.ClickException("GCP project ID must not be empty.")
 
     resolved_namespace = namespace.strip()
+    if resolved_namespace and len(resolved_namespace) > 16:
+        raise click.ClickException(
+            f"Namespace '{resolved_namespace}' is too long ({len(resolved_namespace)} characters). "
+            "It must be 16 characters or less to comply with Google Cloud Service Account ID limits."
+        )
+
     while True:
         if not resolved_namespace:
             resolved_namespace = _prompt("Namespace", type=str).strip()
             if not resolved_namespace:
                 click.secho("Error: Namespace must not be empty.", fg="red")
+                continue
+            if len(resolved_namespace) > 16:
+                click.secho(
+                    f"Error: Namespace must be 16 characters or less (currently {len(resolved_namespace)} characters).",
+                    fg="red",
+                )
+                resolved_namespace = ""
                 continue
 
         target_dir = Path.cwd() / resolved_namespace

--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -233,9 +233,15 @@ def _validate_namespace(ns: str) -> Tuple[bool, str]:
     if not ns:
         return False, "Namespace must not be empty."
     if len(ns) > 16:
-        return False, f"Namespace must be 16 characters or less (currently {len(ns)} characters)."
+        return (
+            False,
+            f"Namespace must be 16 characters or less (currently {len(ns)} characters).",
+        )
     if not re.match(r"^[a-z]([-a-z0-9]*[a-z0-9])?$", ns):
-        return False, "Namespace must start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase alphanumeric characters and dashes."
+        return (
+            False,
+            "Namespace must start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase alphanumeric characters and dashes.",
+        )
     return True, ""
 
 

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -217,7 +217,44 @@ def test_init_db_success(
     result = runner.invoke(admin, ["init-db"])
     assert result.exit_code == 0
     assert "Successfully initialized Spanner database" in result.output
+    assert "Details: DB Initialized" in result.output
     assert "Successfully seeded Spanner database" in result.output
+
+
+@patch("datacommons_admin.tf_utils.shutil.which")
+@patch("datacommons_admin.tf_utils.subprocess.run")
+@patch("datacommons_admin.ingestion_helper_client.AuthorizedSession")
+@patch("datacommons_admin.ingestion_helper_client.google.auth.default")
+def test_init_db_success_no_details(
+    mock_auth_default: patch,
+    mock_session: patch,
+    mock_run: patch,
+    mock_which: patch,
+    runner: CliRunner,
+) -> None:
+    mock_which.return_value = "terraform"
+    from unittest.mock import MagicMock
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = '{"ingestion_service_url": {"value": "https://mock-helper"}, "ingestion_workflow_service_account_email": {"value": "mock-orch-sa@mock.com"}, "spanner_instance_id": {"value": "mock-instance"}, "spanner_database_id": {"value": "mock-db"}}'
+    mock_run.return_value = mock_proc
+
+    mock_creds = MagicMock()
+    mock_auth_default.return_value = (mock_creds, "test-project")
+
+    mock_session_inst = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.ok = True
+    mock_resp.json.return_value = {"status": "success", "message": None}
+    mock_session_inst.post.return_value = mock_resp
+    mock_session.return_value = mock_session_inst
+
+    result = runner.invoke(admin, ["init-db"])
+    assert result.exit_code == 0
+    assert "Successfully initialized Spanner database" in result.output
+    assert "Details:" not in result.output
+    assert "Successfully seeded Spanner database" in result.output
+
 
 
 @patch("datacommons_admin.tf_utils.shutil.which")

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -256,7 +256,6 @@ def test_init_db_success_no_details(
     assert "Successfully seeded Spanner database" in result.output
 
 
-
 @patch("datacommons_admin.tf_utils.shutil.which")
 @patch("datacommons_admin.tf_utils.subprocess.run")
 @patch("datacommons_admin.ingestion_helper_client.AuthorizedSession")


### PR DESCRIPTION
GCP Service Account IDs have a 30-character limit. Some service accounts created during deployment have suffixes up to 13 characters (e.g., `-dc-ing-pre-sa`), leaving a maximum of 16 characters for the user-specified namespace.

This change adds validation to the CLI:
- Raises an error immediately if a namespace flag exceeding 16 characters or containing invalid characters is provided.
- Re-prompts the user in interactive mode if they input an invalid namespace.

### Naming Rules Enforced:
- Maximum 16 characters.
- Must start with a lowercase letter.
- Must end with a lowercase letter or number.
- Can only contain lowercase alphanumeric characters and dashes (`-`).

---

### How to Test

You can test these changes directly using `uvx` without needing to clone the repository or install dependencies locally.

#### 1. Flag Namespace Exceeds Limit
Run the init command with a namespace longer than 16 characters. It should fail immediately:
```bash
uvx --no-cache --from "git+https://github.com/clincoln8/datacommons.git@enforce-namespace-limit#subdirectory=packages/datacommons-cli" \
    datacommons admin init --project-id test --namespace too-long-namespace-name
```
*Expected Output:*
`Error: Namespace must be 16 characters or less (currently 23 characters).`

#### 2. Flag Namespace Contains Invalid Characters
Run with invalid characters (e.g., uppercase, underscore, ending with dash):
```bash
uvx --no-cache --from "git+https://github.com/clincoln8/datacommons.git@enforce-namespace-limit#subdirectory=packages/datacommons-cli" \
    datacommons admin init --project-id test --namespace Invalid_Namespace-
```
*Expected Output:*
`Error: Namespace must start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase alphanumeric characters and dashes.`

#### 3. Interactive Prompt Validation (Invalid then Valid)
Run without the namespace flag to trigger the prompt. Try entering an invalid namespace first, then a valid one:
```bash
uvx --no-cache --from "git+https://github.com/clincoln8/datacommons.git@enforce-namespace-limit#subdirectory=packages/datacommons-cli" \
    datacommons admin init --project-id test
```
*Testing steps:*
1. At the `Namespace:` prompt, enter: `too-long-namespace-name`
   *Expected:* Shows error `Namespace must be 16 characters or less...` and prompts again.
2. Enter: `invalid_char`
   *Expected:* Shows error `Namespace must start with a lowercase...` and prompts again.
3. Enter: `valid-ns`
   *Expected:* Passes validation and proceeds to the next step (`Create this bucket? [Y/n]`). You can press `n` to abort.

#### 4. Valid Flag Namespace
Run with a valid namespace flag. It should pass validation immediately and proceed to the bucket creation prompt:
```bash
uvx --no-cache --from "git+https://github.com/clincoln8/datacommons.git@enforce-namespace-limit#subdirectory=packages/datacommons-cli" \
    datacommons admin init --project-id test --namespace valid-ns
```
*Expected Output:* Proceeds to `Create this bucket? [Y/n]`. (Press `n` to abort).

#### 5. Valid Prompted Namespace (First Try)
Run without the namespace flag and enter a valid one on the first try:
```bash
uvx --no-cache --from "git+https://github.com/clincoln8/datacommons.git@enforce-namespace-limit#subdirectory=packages/datacommons-cli" \
    datacommons admin init --project-id test
```
*Testing steps:*
1. At the `Namespace:` prompt, enter: `valid-ns`
   *Expected:* Proceeds to `Create this bucket? [Y/n]`. (Press `n` to abort).

TAG=agy
CONV=a76b3d6e-4c0b-421f-956a-5b8624f47e56
