### PR TITLE
Fix preprocessor DATA_RUN_MODE environment variable override

### DIFF
--- a/packages/datacommons-admin/datacommons_admin/ingestion_job_client.py
+++ b/packages/datacommons-admin/datacommons_admin/ingestion_job_client.py
@@ -62,15 +62,9 @@ class IngestionJobClient:
         """Starts an execution of the Cloud Run job."""
         url = f"https://run.googleapis.com/v2/{self.full_job_name}:run"
 
-        args = []
+        container_override = {"env": [{"name": "DATA_RUN_MODE", "value": "dcpbridge"}]}
         if imports:
-            args.append(f"--imports={imports}")
-
-        container_override = {
-            "env": [{"name": "DATA_RUN_MODE", "value": "dcpbridge"}]
-        }
-        if args:
-            container_override["args"] = args
+            container_override["args"] = [f"--imports={imports}"]
 
         json_payload = {"overrides": {"containerOverrides": [container_override]}}
 

--- a/packages/datacommons-admin/datacommons_admin/ingestion_job_client.py
+++ b/packages/datacommons-admin/datacommons_admin/ingestion_job_client.py
@@ -62,11 +62,17 @@ class IngestionJobClient:
         """Starts an execution of the Cloud Run job."""
         url = f"https://run.googleapis.com/v2/{self.full_job_name}:run"
 
-        args = ["--mode=dcpbridge"]
+        args = []
         if imports:
             args.append(f"--imports={imports}")
 
-        json_payload = {"overrides": {"containerOverrides": [{"args": args}]}}
+        container_override = {
+            "env": [{"name": "DATA_RUN_MODE", "value": "dcpbridge"}]
+        }
+        if args:
+            container_override["args"] = args
+
+        json_payload = {"overrides": {"containerOverrides": [container_override]}}
 
         try:
             response = self.session.post(url, json=json_payload, timeout=300)

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -446,7 +446,10 @@ def test_ingest_start_with_imports_success(
         json={
             "overrides": {
                 "containerOverrides": [
-                    {"args": ["--mode=dcpbridge", "--imports=oecd,doubleup"]}
+                    {
+                        "env": [{"name": "DATA_RUN_MODE", "value": "dcpbridge"}],
+                        "args": ["--imports=oecd,doubleup"],
+                    }
                 ]
             }
         },


### PR DESCRIPTION
### Problem
When starting the ingestion preprocessing job, the Admin CLI was overriding the container arguments with `--mode=dcpbridge` but not the environment variable `DATA_RUN_MODE`.

Because of this, `run.sh` in the container fell back to `customdc` run mode (see [run.sh lines 35-43](https://github.com/datacommonsorg/website/blob/master/build/cdc_data/run.sh#L35-L43)):
```bash
if [[ $DATA_RUN_MODE != "" ]]; then
    ...
else
  DATA_RUN_MODE="customdc"
fi
```
Consequently, it evaluated `$DATA_RUN_MODE` as `"customdc"` and skipped the skip-embeddings check (which expects `dcpbridge`), causing it to start the legacy embeddings builder (see [run.sh lines 90-100](https://github.com/datacommonsorg/website/blob/master/build/cdc_data/run.sh#L90-L100)):
```bash
elif [[ $DATA_RUN_MODE == "dcpbridge" && $ENABLE_SPANNER_EMBEDDINGS == "true" ]]; then
    : # skip GCS embeddings for DCP
else
    echo "Starting embeddings builder..."
    python3 -m tools.nl.embeddings.build_embeddings ...
```

### Solution
Instead of passing `--mode=dcpbridge` as a command-line argument override, we pass it as a `DATA_RUN_MODE=dcpbridge` environment variable override. The container's `run.sh` automatically forwards it to `stats.main` via `--mode=$DATA_RUN_MODE`, while also correctly allowing the shell script to skip legacy embeddings generation.

### Tested
https://screenshot.googleplex.com/3uQi97eoayC7SrV