### PR TITLE
Expose Dataflow template GCS path as Terraform variable

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -138,8 +138,9 @@ locals {
     helper_service_image              = var.ingestion_helper_service_image
 
     # Dataflow Network Configuration
-    dataflow_ip_configuration = var.ingestion_dataflow_ip_configuration
-    dataflow_subnetwork       = var.ingestion_dataflow_subnetwork
+    dataflow_ip_configuration  = var.ingestion_dataflow_ip_configuration
+    dataflow_subnetwork        = var.ingestion_dataflow_subnetwork
+    dataflow_template_gcs_path = var.ingestion_dataflow_template_gcs_path
   }
 }
 

--- a/infra/dcp/modules/ingestion/helper_service/variables.tf
+++ b/infra/dcp/modules/ingestion/helper_service/variables.tf
@@ -32,8 +32,7 @@ variable "ingestion_bucket_name" {
 }
 
 variable "image" {
-  type    = string
-  default = "gcr.io/datcom-ci/datacommons-ingestion-helper:1.0.0"
+  type = string
 }
 
 variable "bigquery_connection_id" {

--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -89,7 +89,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
                     body:
                       launchParameter:
                         jobName: '$${dataflow_job_name}'
-                        containerSpecGcsPath: 'gs://datcom-templates/templates/flex/ingestion-stable.json'
+                        containerSpecGcsPath: '${var.dataflow_template_gcs_path}'
                         parameters: '$${launch_params}'
                         environment:
                           serviceAccountEmail: '${var.dataflow_service_account_email}'

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -107,3 +107,16 @@ check "dataflow_private_ip_requires_subnetwork" {
     error_message = "dataflow_subnetwork must be specified when dataflow_ip_configuration is WORKER_IP_PRIVATE."
   }
 }
+
+variable "dataflow_template_gcs_path" {
+  type        = string
+  description = "GCS path to the Dataflow Flex Template container spec"
+  default     = "gs://datcom-templates/templates/flex/ingestion-dacf16d.json"
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^gs://.+[.]json$", var.dataflow_template_gcs_path))
+    error_message = "The dataflow_template_gcs_path must be a valid GCS path starting with 'gs://' and ending with '.json'."
+  }
+}
+

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -200,6 +200,7 @@ module "ingestion_workflow" {
   ingestion_artifacts_path       = "${var.ingestion_config.ingestion_artifacts_path}/metadata"
   dataflow_ip_configuration      = var.ingestion_config.dataflow_ip_configuration
   dataflow_subnetwork            = var.ingestion_config.dataflow_subnetwork
+  dataflow_template_gcs_path     = var.ingestion_config.dataflow_template_gcs_path
 
   depends_on = [module.ingestion_helper_service]
 }

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -86,7 +86,7 @@ variable "ingestion_config" {
     workflow_enable_bigquery_postprocessing = bool
 
     # Storage & Paths
-    input_path              = string
+    input_path               = string
     ingestion_artifacts_path = string
 
     # Preprocessing Job
@@ -102,7 +102,8 @@ variable "ingestion_config" {
     # Dataflow network configuration
     # Use WORKER_IP_PRIVATE when a compute.vmExternalIpAccess org policy
     # blocks Dataflow workers from obtaining external IPs.
-    dataflow_ip_configuration = optional(string, "WORKER_IP_UNSPECIFIED")
-    dataflow_subnetwork       = optional(string, "")
+    dataflow_ip_configuration  = optional(string, "WORKER_IP_UNSPECIFIED")
+    dataflow_subnetwork        = optional(string, "")
+    dataflow_template_gcs_path = optional(string)
   })
 }

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -397,3 +397,14 @@ variable "ingestion_dataflow_subnetwork" {
   type        = string
   default     = ""
 }
+
+# =============================================================================
+# Ingestion - Dataflow Template Configuration
+# =============================================================================
+
+variable "ingestion_dataflow_template_gcs_path" {
+  description = "GCS path to the Dataflow Flex Template container spec. If not provided (null), defaults to the stable template defined in the workflow module (modules/ingestion/workflow/variables.tf)."
+  type        = string
+  default     = null
+}
+


### PR DESCRIPTION
Exposes the Dataflow Flex Template container spec path as a Terraform variable `ingestion_dataflow_template_gcs_path` at the root level, freezing this as current stable `ingestion-dacf16d.json`. 

This allows overriding the template version at deployment time and we'll bump this to 1.0.1 once we have e2e working.