### PR TITLE
feat(infra): bump default DCP images to 1.1.0 and encapsulate defaults

### DIFF
--- a/infra/dcp/modules/datacommons_services/variables.tf
+++ b/infra/dcp/modules/datacommons_services/variables.tf
@@ -22,7 +22,10 @@ variable "stateless_deletion_protection" {
 # Container Configuration
 # =============================================================================
 variable "image" {
-  type = string
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-services:1.1.0"
+  nullable    = false
+  description = "Docker image URL for the main Data Commons services"
 }
 
 variable "cpu" {

--- a/infra/dcp/modules/ingestion/helper_service/variables.tf
+++ b/infra/dcp/modules/ingestion/helper_service/variables.tf
@@ -32,7 +32,10 @@ variable "ingestion_bucket_name" {
 }
 
 variable "image" {
-  type = string
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-ingestion-helper:1.1.0"
+  nullable    = false
+  description = "Docker image URL for the ingestion support service"
 }
 
 variable "bigquery_connection_id" {

--- a/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
@@ -5,7 +5,12 @@ variable "stateless_deletion_protection" {
   type        = bool
   description = "Enable deletion protection for stateless resources (Cloud Run Job) to prevent accidental deletion."
 }
-variable "image" { type = string }
+variable "image" {
+  type        = string
+  default     = "gcr.io/datcom-ci/datacommons-data:1.1.0"
+  nullable    = false
+  description = "Docker image URL for the data ingestion pre-processing job"
+}
 variable "cpu" { type = string }
 variable "memory" { type = string }
 variable "timeout" { type = string }

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -111,7 +111,7 @@ check "dataflow_private_ip_requires_subnetwork" {
 variable "dataflow_template_gcs_path" {
   type        = string
   description = "GCS path to the Dataflow Flex Template container spec"
-  default     = "gs://datcom-templates/templates/flex/ingestion-dacf16d.json"
+  default     = "gs://datcom-templates/templates/flex/ingestion-1.1.0.json"
   nullable    = false
 
   validation {

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -38,7 +38,7 @@ variable "spanner_config" {
 variable "datacommons_services_config" {
   type = object({
     enable                          = bool
-    image                           = string
+    image                           = optional(string)
     name                            = string
     min_instances                   = number
     max_instances                   = number
@@ -90,14 +90,14 @@ variable "ingestion_config" {
     ingestion_artifacts_path = string
 
     # Preprocessing Job
-    preprocessing_job_image   = string
+    preprocessing_job_image   = optional(string)
     preprocessing_job_cpu     = string
     preprocessing_job_memory  = string
     preprocessing_job_timeout = string
 
     # Workflow & Helper Service
     workflow_lock_acquisition_timeout = number
-    helper_service_image              = string
+    helper_service_image              = optional(string)
 
     # Dataflow network configuration
     # Use WORKER_IP_PRIVATE when a compute.vmExternalIpAccess org policy

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -232,9 +232,9 @@ variable "enable_datacommons_services" {
 }
 
 variable "datacommons_services_image" {
-  description = "Docker image URL for the main Data Commons services"
+  description = "Docker image URL for the main Data Commons services. If not provided (null), defaults to the stable image defined in the services module (modules/datacommons_services/variables.tf)."
   type        = string
-  default     = "gcr.io/datcom-ci/datacommons-services:1.0.0"
+  default     = null
 }
 
 variable "datacommons_services_name" {
@@ -315,9 +315,9 @@ variable "datacommons_services_resolve_with_spanner_embeddings" {
 # =============================================================================
 
 variable "ingestion_preprocessing_job_image" {
-  description = "Docker image URL for the data ingestion pre-processing job"
+  description = "Docker image URL for the data ingestion pre-processing job. If not provided (null), defaults to the stable image defined in the preprocessing module (modules/ingestion/preprocessing_job/variables.tf)."
   type        = string
-  default     = "gcr.io/datcom-ci/datacommons-data:1.0.0"
+  default     = null
 }
 
 variable "ingestion_preprocessing_job_cpu" {
@@ -377,9 +377,9 @@ variable "ingestion_artifacts_path" {
 # =============================================================================
 
 variable "ingestion_helper_service_image" {
-  description = "Docker image URL for the ingestion support service"
+  description = "Docker image URL for the ingestion support service. If not provided (null), defaults to the stable image defined in the helper service module (modules/ingestion/helper_service/variables.tf)."
   type        = string
-  default     = "gcr.io/datcom-ci/datacommons-ingestion-helper:1.0.0"
+  default     = null
 }
 
 # =============================================================================


### PR DESCRIPTION
This PR bumps the default versions of all core DCP images (ingestion helper, cdc-data, cdc-services) and the Dataflow Flex Template to `1.1.0`.

It also refactors how these defaults are managed to improve encapsulation and upgradeability:
- **Encapsulation**: Default values are moved from the top-level `infra/dcp/variables.tf` down to their respective lowest-level modules (`modules/datacommons_services`, `modules/ingestion/preprocessing_job`, and `modules/ingestion/helper_service`).
- **Seamless Upgrades**: Top-level variables are now optional and default to `null`. The mid-level `stack` module propagates these down, and the lowest-level modules use `nullable = false` to resolve `null` to the stable defaults. This means users upgrading their stack version in `main.tf` will automatically get the new default images without needing to manually update their local `variables.tf`.
- **Documentation**: Top-level variable descriptions have been updated to clearly document that they default to the stable versions defined in the modules.

### Changes
- `infra/dcp/variables.tf`: Make image variables optional (default to `null`) and update descriptions.
- `infra/dcp/modules/stack/variables.tf`: Make image fields optional in config objects.
- `infra/dcp/modules/datacommons_services/variables.tf`: Set default to `1.1.0` and `nullable = false`.
- `infra/dcp/modules/ingestion/preprocessing_job/variables.tf`: Set default to `1.1.0` and `nullable = false`.
- `infra/dcp/modules/ingestion/helper_service/variables.tf`: Set default to `1.1.0` and `nullable = false`.
- `infra/dcp/modules/ingestion/workflow/variables.tf`: Bump default Dataflow template path to `1.1.0`.

### Verification
- Ran `terraform init -backend=false` and `terraform validate` in `infra/dcp` successfully.

TAG=agy
CONV=32d08e37-a92e-4464-b396-32ec79c17137
