### PR TITLE
fix(github-actions): allow optional trailing PR numbers in release trigger regex

### DIFF
--- a/.github/workflows/auto_draft_release.yaml
+++ b/.github/workflows/auto_draft_release.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           commit_msg=$(git log -1 --pretty=%B)
           echo "Commit message: $commit_msg"
-          if [[ "$commit_msg" =~ ^chore:\ bump\ version\ to\ ([0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)$ ]]; then
+          if [[ "$commit_msg" =~ ^chore:\ bump\ version\ to\ ([0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?) ]]; then
             version="${BASH_REMATCH[1]}"
             echo "is_bump=true" >> $GITHUB_OUTPUT
             echo "version=$version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Relaxes the regex end-of-line anchor (`$`) in `auto_draft_release.yaml` to ensure that automated draft releases trigger when GitHub appends PR merge numbers (e.g., `chore: bump version to 1.1.0 (#139)`).