### PR TITLE
Feature/enable hermetic integration test at merging time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,27 +37,32 @@ jobs:
           # Enable parallel test execution
           uv run pytest
 
-#  hermetic-integration-test:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v5
-#
-#      - name: Install uv and set the Python version
-#        uses: astral-sh/setup-uv@v6
-#        with:
-#          python-version: "3.12"
-#
-#      - name: Install dependencies
-#        run: uv sync --locked
-#
-#      # Runs the integration tests using Docker Compose.
-#      # Note: By default, this pulls the `stable` image tags defined in docker-compose.test.yml.
-#      # To validate against a specific releasing version or pinned tag (e.g. during a release candidate build),
-#      # you can override the target images by setting the env variables, for example:
-#      # env:
-#      #   HELPER_IMAGE: gcr.io/datcom-ci/datacommons-ingestion-helper:v1.2.3rc1
-#      #   SERVICES_IMAGE: gcr.io/datcom-ci/datacommons-services:v1.2.3rc1
-#      - name: Run hermetic integration test
-#        run: uv run pytest -s tests/datacommons-integration-tests/run_local_integration_test.py
+  hermetic-integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install uv and set the Python version
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      # Runs the integration tests using Docker Compose.
+      # Note: This tests the local Python package code on the host runner against
+      # pre-built backend service containers. By default, the containers pull
+      # the `:latest` image tags defined in docker-compose.test.yml.
+      # To validate against a specific release version or pinned tag (e.g. during a release candidate build),
+      # you can override the target images by setting the env variables, for example:
+      # env:
+      #   HELPER_IMAGE: gcr.io/datcom-ci/datacommons-ingestion-helper:v1.2.3rc1
+      #   SERVICES_IMAGE: gcr.io/datcom-ci/datacommons-services:v1.2.3rc1
+      - name: Run hermetic integration test
+        run: uv run pytest -s tests/datacommons-integration-tests/run_local_integration_test.py
+
+
+
 

--- a/tests/datacommons-integration-tests/run_local_integration_test.py
+++ b/tests/datacommons-integration-tests/run_local_integration_test.py
@@ -473,8 +473,13 @@ def test_spanner_observations(generate_golden):
 def test_website_semantic_nl_query(generate_golden):
     """Verify that Mixer fulfills NL queries using the seeded Spanner graph."""
     url = f"http://localhost:{WEBSITE_PORT}/api/explore/detect-and-fulfill"
+    # CAVEAT / WORKAROUND:
+    # Cloud Spanner Emulator does not support vector indexes or ANN search queries
+    # (APPROX_COSINE_DISTANCE), failing query compilation with validation errors.
+    # We bypass it for local integration tests by disabling Spanner vector search.
+    # IMPORTANT: Real GCP-based integration tests must cover this active vector search path.
     resp = requests.post(
-        f"{url}?q=Number+of+frogs+in+United+States+of+America",
+        f"{url}?q=Number+of+frogs+in+United+States+of+America&disable_feature=use_v2_resolve_for_nl_search_vars",
         json={"contextHistory": []},
         timeout=120,
     )


### PR DESCRIPTION
particularly adding use_v2_resolve_for_nl_search_vars=false workaround because we are using spanner emulator which doesn't support this feature yet (we are relying on gcr.io/cloud-spanner-emulator/emulator which doesn't support this yet, it seems)