### PR TITLE
feat: implement service client & global FastAPI error propagation

### DIFF
--- a/packages/datacommons-api/datacommons_api/app.py
+++ b/packages/datacommons-api/datacommons_api/app.py
@@ -12,10 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from fastapi import FastAPI
+"""Main FastAPI application definition."""
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.openapi.utils import get_openapi
+from pydantic import BaseModel, Field
 
 from datacommons_api.endpoints.routers import node_router
+from datacommons_api.core.exceptions import (
+    APIKeyUnauthorizedError,
+    APIKeyForbiddenError,
+)
+from datacommons_api.core.logging import get_logger
 from . import __version__
+
+logger = get_logger(__name__)
 
 # FastAPI initialization
 app = FastAPI(
@@ -26,5 +38,104 @@ app = FastAPI(
     redoc_url="/redoc",
     debug=True,
 )
+
+
+# Standardized error response model for OpenAPI documentation
+class APIKeyErrorResponse(BaseModel):
+    error: str = Field(
+        ...,
+        description="The error type.",
+        json_schema_extra={"example": "Unauthorized"},
+    )
+    message: str = Field(
+        ...,
+        description="Actionable explanation of the error.",
+        json_schema_extra={
+            "example": "The Data Commons API server key is invalid or expired. Please contact the administrator."
+        },
+    )
+    code: str = Field(
+        ...,
+        description="Standardized error code.",
+        json_schema_extra={"example": "API_KEY_UNAUTHORIZED"},
+    )
+
+
+# Exception Handlers
+@app.exception_handler(APIKeyUnauthorizedError)
+async def api_key_unauthorized_exception_handler(
+    request: Request, exc: APIKeyUnauthorizedError
+):
+    logger.critical(
+        "CRITICAL: The configured DC_API_KEY is invalid, expired, or unauthorized. "
+        "Please verify your deployment settings."
+    )
+    return JSONResponse(
+        status_code=401,
+        content={
+            "error": "Unauthorized",
+            "message": "The Data Commons API server key is invalid or expired. Please contact the administrator.",
+            "code": "API_KEY_UNAUTHORIZED",
+        },
+    )
+
+
+@app.exception_handler(APIKeyForbiddenError)
+async def api_key_forbidden_exception_handler(
+    request: Request, exc: APIKeyForbiddenError
+):
+    logger.critical(
+        "CRITICAL: The configured DC_API_KEY does not have permission to access the central API."
+    )
+    return JSONResponse(
+        status_code=403,
+        content={
+            "error": "Forbidden",
+            "message": "The Data Commons API server key lacks permissions to access the requested resource. Please contact the administrator.",
+            "code": "API_KEY_FORBIDDEN",
+        },
+    )
+
+
+# Override OpenAPI generator to document 401 & 403 globally
+def custom_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        routes=app.routes,
+    )
+    # Add 401 and 403 responses to all routes except health checks
+    for path, methods in openapi_schema.get("paths", {}).items():
+        if path in ("/healthz", "/status"):
+            continue
+        for method in methods.values():
+            method.setdefault("responses", {})
+            method["responses"]["401"] = {
+                "description": "Unauthorized - API Key is invalid or expired",
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": "#/components/schemas/APIKeyErrorResponse"}
+                    }
+                },
+            }
+            method["responses"]["403"] = {
+                "description": "Forbidden - API Key lacks permissions",
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": "#/components/schemas/APIKeyErrorResponse"}
+                    }
+                },
+            }
+    openapi_schema.setdefault("components", {}).setdefault("schemas", {})
+    openapi_schema["components"]["schemas"]["APIKeyErrorResponse"] = (
+        APIKeyErrorResponse.model_json_schema()
+    )
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
+app.openapi = custom_openapi
 
 app.include_router(node_router.router, tags=["nodes"])

--- a/packages/datacommons-api/datacommons_api/services/central_api_client.py
+++ b/packages/datacommons-api/datacommons_api/services/central_api_client.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Client wrapper for the central Data Commons API."""
+
+import requests
+from datacommons_api.core.exceptions import (
+    APIKeyUnauthorizedError,
+    APIKeyForbiddenError,
+)
+
+
+class CentralAPIClient:
+    """Client for querying the central Data Commons API."""
+
+    def __init__(self, api_key: str, base_url: str = "https://api.datacommons.org"):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.session = requests.Session()
+
+    def query_usa_population(self, timeout: float = 3.0) -> dict:
+        """Perform a lightweight USA population query to validate the key."""
+        url = f"{self.base_url}/v2/observation"
+        headers = {
+            "Content-Type": "application/json",
+            "X-Goog-Api-Key": self.api_key,
+        }
+        payload = {
+            "entity": {"dcids": ["country/USA"]},
+            "variable": {"dcids": ["Count_Person"]},
+            "date": "latest",
+        }
+
+        # Make the request passing the key securely via header.
+        response = self.session.post(
+            url,
+            headers=headers,
+            json=payload,
+            timeout=timeout,
+        )
+
+        if response.status_code == 401:
+            raise APIKeyUnauthorizedError("Invalid or expired API key.")
+        if response.status_code == 403:
+            raise APIKeyForbiddenError("API key lacks permissions or is forbidden.")
+
+        response.raise_for_status()
+        return response.json()

--- a/packages/datacommons-api/tests/services/test_central_api_client.py
+++ b/packages/datacommons-api/tests/services/test_central_api_client.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for CentralAPIClient."""
+
+from unittest.mock import patch, MagicMock
+import pytest
+import requests
+
+from datacommons_api.core.exceptions import (
+    APIKeyUnauthorizedError,
+    APIKeyForbiddenError,
+)
+from datacommons_api.services.central_api_client import CentralAPIClient
+
+
+def test_query_success():
+    client = CentralAPIClient(api_key="valid-key")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"data": "success"}
+
+    with patch("requests.Session.post", return_value=mock_response) as mock_post:
+        result = client.query_usa_population()
+
+        assert result == {"data": "success"}
+        mock_post.assert_called_once()
+        # Verify headers have the key
+        called_headers = mock_post.call_args[1].get("headers", {})
+        assert called_headers.get("X-Goog-Api-Key") == "valid-key"
+
+
+def test_query_unauthorized():
+    client = CentralAPIClient(api_key="invalid-key")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+
+    with patch("requests.Session.post", return_value=mock_response):
+        with pytest.raises(APIKeyUnauthorizedError) as exc_info:
+            client.query_usa_population()
+        assert "Invalid or expired API key" in str(exc_info.value)
+
+
+def test_query_forbidden():
+    client = CentralAPIClient(api_key="forbidden-key")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+
+    with patch("requests.Session.post", return_value=mock_response):
+        with pytest.raises(APIKeyForbiddenError) as exc_info:
+            client.query_usa_population()
+        assert "API key lacks permissions" in str(exc_info.value)
+
+
+def test_query_timeout_propagates():
+    client = CentralAPIClient(api_key="valid-key")
+
+    with patch(
+        "requests.Session.post",
+        side_effect=requests.exceptions.Timeout("Connection timed out"),
+    ):
+        with pytest.raises(requests.exceptions.Timeout) as exc_info:
+            client.query_usa_population()
+        assert "Connection timed out" in str(exc_info.value)

--- a/packages/datacommons-api/tests/test_app_exceptions.py
+++ b/packages/datacommons-api/tests/test_app_exceptions.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for FastAPI exception handlers and OpenAPI documentation."""
+
+from fastapi.testclient import TestClient
+import pytest
+
+from datacommons_api.app import app
+from datacommons_api.core.exceptions import (
+    APIKeyUnauthorizedError,
+    APIKeyForbiddenError,
+)
+
+
+# Register temporary test routes on the app
+@app.get("/test-unauthorized", tags=["test"])
+def route_unauthorized():
+    raise APIKeyUnauthorizedError("test unauthorized")
+
+
+@app.get("/test-forbidden", tags=["test"])
+def route_forbidden():
+    raise APIKeyForbiddenError("test forbidden")
+
+
+client = TestClient(app)
+
+
+def test_unauthorized_exception_handler():
+    response = client.get("/test-unauthorized")
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": "Unauthorized",
+        "message": "The Data Commons API server key is invalid or expired. Please contact the administrator.",
+        "code": "API_KEY_UNAUTHORIZED",
+    }
+
+
+def test_forbidden_exception_handler():
+    response = client.get("/test-forbidden")
+    assert response.status_code == 403
+    assert response.json() == {
+        "error": "Forbidden",
+        "message": "The Data Commons API server key lacks permissions to access the requested resource. Please contact the administrator.",
+        "code": "API_KEY_FORBIDDEN",
+    }
+
+
+def test_openapi_documentation():
+    # Force recreation of OpenAPI schema to ensure our custom generator runs
+    app.openapi_schema = None
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    schema = response.json()
+
+    # Verify schema definition is present
+    components = schema.get("components", {})
+    schemas = components.get("schemas", {})
+    assert "APIKeyErrorResponse" in schemas
+
+    error_response_schema = schemas["APIKeyErrorResponse"]
+    assert "error" in error_response_schema["properties"]
+    assert "message" in error_response_schema["properties"]
+    assert "code" in error_response_schema["properties"]
+
+    # Verify that standard routes (e.g. from node_router) document 401 and 403
+    # Let's find a non-test path in the schema.
+    # Our node_router usually registers some paths, let's look for one.
+    paths = schema.get("paths", {})
+
+    # We want to find a real route (not our /test-unauthorized or /test-forbidden)
+    real_paths = [
+        p
+        for p in paths.keys()
+        if p not in ("/test-unauthorized", "/test-forbidden", "/healthz", "/status")
+    ]
+
+    if real_paths:
+        target_path = real_paths[0]
+        for method_schema in paths[target_path].values():
+            responses = method_schema.get("responses", {})
+            assert "401" in responses
+            assert "403" in responses
+            # Verify they reference our APIKeyErrorResponse schema
+            assert (
+                responses["401"]["content"]["application/json"]["schema"]["$ref"]
+                == "#/components/schemas/APIKeyErrorResponse"
+            )
+            assert (
+                responses["403"]["content"]["application/json"]["schema"]["$ref"]
+                == "#/components/schemas/APIKeyErrorResponse"
+            )


### PR DESCRIPTION
**PR 2 of 3 (Stacked)**
* **Source**: `premr/api-key-error-propagation`
* **Target**: `premr/api-key-redaction-foundation`

### 1. Context & Motivation (PRD)
Previously, a misconfigured or invalid API key caused the local server to boot silently and fail only at runtime, returning raw, uninformative HTTP 500 errors to client-side developers (such as Web Components or static sites) and causing application hangs.

This PR implements the service-layer client wrapper and global web-boundary exception handlers to intercept credential failures and return clean, standardized JSON payloads to developers.

### 2. Key Changes
* **Service client (`datacommons_api/services/central_api_client.py`)**:
  * Created `CentralAPIClient` performing lightweight POST queries (USA population check) to the central API gateway.
  * Intercepts HTTP `401` and `403` status codes and maps them to `APIKeyUnauthorizedError` and `APIKeyForbiddenError` respectively.
* **FastAPI Exception Handlers (`datacommons_api/app.py`)**:
  * Registered global exception handlers that catch these custom exceptions, log a prominent `CRITICAL` alert to warn server administrators, and return secure, standardized JSON payloads to calling developers (with status codes `401` and `403`), preventing application hangs.
* **Auto-Documenting OpenAPI Schema (`datacommons_api/app.py`)**:
  * Overrode FastAPI's default OpenAPI schema generator to dynamically inject `401` and `403` responses into all endpoints (excluding health checks). This automatically documents these failure modes in the Swagger UI and client-side SDKs.

### 3. Verification & Tests
* Implemented `tests/services/test_central_api_client.py` and `tests/test_app_exceptions.py` (using FastAPI `TestClient`).
* Verified client status mapping, global exception routing, standardized JSON bodies, and `/openapi.json` schema documentation. All tests pass 100% cleanly.
