### PR TITLE
feat: implement CLI startup validation & background health status telemetry

### DIFF
--- a/packages/datacommons-api/README.md
+++ b/packages/datacommons-api/README.md
@@ -323,3 +323,74 @@ You should see the:
   ]
 }
 ```
+
+
+## API Key Configuration & Diagnostics
+
+The Data Commons API server requires a valid `DC_API_KEY` to authenticate federated queries to the central Data Commons API backend (`api.datacommons.org`). This section describes how to configure the key, how the server handles errors, and how to monitor the server's health status.
+
+### 1. Configuration Environment Variables
+
+You can configure the server's API key behavior using the following environment variables:
+
+| Environment Variable | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `DC_API_KEY` | String | None | The Google API key used to authenticate requests to the central Data Commons API (`api.datacommons.org`). |
+| `DC_API_KEY_OPTIONAL` | Boolean | `false` | If set to `true`, the server is allowed to boot even if `DC_API_KEY` is missing or empty. If a key *is* provided, it will still be validated on startup. Useful for local offline development. |
+| `DC_API_KEY_STRICT_VALIDATION` | Boolean | `false` | If set to `true`, the server will fail-fast and halt startup if the central API is unreachable (network timeout or 5xx error). By default (Resilient Fail-Open), the server will log a warning, boot in degraded mode, and attempt background re-validation. |
+
+### 2. Runtime Error Handling & Propagation
+
+If a federated request to `api.datacommons.org` fails with a credential error at runtime, the server intercepts it and returns a standardized, secure JSON response with an appropriate HTTP status code. The server's sensitive API key is completely redacted from all tracebacks and logs.
+
+#### Standardized Error Payload (HTTP 401 / 403)
+```json
+{
+  "error": "Unauthorized",
+  "message": "The Data Commons API server key is invalid or expired. Please contact the administrator.",
+  "code": "API_KEY_UNAUTHORIZED"
+}
+```
+
+*   **HTTP 401 (API_KEY_UNAUTHORIZED):** Returned when the configured `DC_API_KEY` is invalid, expired, or deactivated.
+*   **HTTP 403 (API_KEY_FORBIDDEN):** Returned when the configured `DC_API_KEY` lacks permissions to access the requested resource.
+
+### 3. Health & Status Diagnostics (`/healthz`)
+
+The server exposes a detailed health check endpoint at `/healthz` (with a hidden alias at `/status`). This endpoint returns the server's overall status, degraded state, and detailed API key health:
+
+#### Healthy State (HTTP 200 OK)
+Returned when the API key has been successfully verified (or when the key check was bypassed because `DC_API_KEY_OPTIONAL=true` and no key was provided):
+```json
+{
+  "status": "healthy",
+  "degraded": false,
+  "api_key_status": "verified"
+}
+```
+
+#### Degraded Warning State (HTTP 200 OK)
+Returned when the server booted successfully but the central API was unreachable due to transient network issues:
+```json
+{
+  "status": "degraded",
+  "degraded": true,
+  "api_key_status": "unverified",
+  "critical": false,
+  "message": "Data Commons API key is unverified due to network issues. Operating in degraded fail-open mode."
+}
+```
+*Note: A background worker runs in a non-blocking thread, retrying validation every 1 minute. If validation succeeds later, the server automatically exits degraded mode.*
+
+#### Unhealthy / Outage State (HTTP 503 Service Unavailable)
+Returned if the API key is confirmed to be invalid (401/403) or if the background re-validation worker has failed continuously for **30 minutes** (indicating a persistent network outage or misconfiguration):
+```json
+{
+  "status": "unhealthy",
+  "degraded": true,
+  "api_key_status": "invalid",
+  "critical": true,
+  "message": "Data Commons API key validation has failed continuously. Spanner queries remain available."
+}
+```
+*Use this endpoint in Kubernetes liveness/readiness probes or load-balancer health checks to trigger automated alerts and rollbacks.*

--- a/packages/datacommons-api/datacommons_api/api_cli.py
+++ b/packages/datacommons-api/datacommons_api/api_cli.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import sys
 import click
 import uvicorn
 
@@ -20,10 +22,58 @@ from datacommons_api.core.config import get_config, initialize_config
 from datacommons_api.core.logging import get_logger, setup_logging
 from datacommons_db.session import get_session
 from datacommons_api.services.graph_service import GraphService
+from datacommons_api.services.central_api_client import CentralAPIClient
+from datacommons_api.core.exceptions import (
+    APIKeyUnauthorizedError,
+    APIKeyForbiddenError,
+)
 from . import __version__
 
 setup_logging()
 logger = get_logger(__name__)
+
+
+def validate_api_key_startup() -> None:
+    """Synchronously validate DC_API_KEY at startup."""
+    api_key = os.getenv("DC_API_KEY", "").strip()
+    optional_bypass = os.getenv("DC_API_KEY_OPTIONAL", "").lower() == "true"
+    strict_mode = os.getenv("DC_API_KEY_STRICT_VALIDATION", "").lower() == "true"
+
+    if not api_key:
+        if optional_bypass:
+            logger.warning(
+                "Warning: DC_API_KEY is missing, but startup is allowed due to bypass configuration."
+            )
+            os.environ["_DC_API_KEY_STARTUP_DEGRADED"] = "true"
+            os.environ["_DC_API_KEY_STATUS"] = "bypassed"
+            return
+        sys.stderr.write("Error: DC_API_KEY environment variable is missing.\n")
+        sys.exit(1)
+
+    client = CentralAPIClient(api_key=api_key)
+    try:
+        client.query_usa_population(timeout=3.0)
+        logger.info("DC_API_KEY validation successful.")
+        os.environ["_DC_API_KEY_STARTUP_DEGRADED"] = "false"
+        os.environ["_DC_API_KEY_STATUS"] = "verified"
+    except (APIKeyUnauthorizedError, APIKeyForbiddenError) as e:
+        sys.stderr.write(
+            f"Error: Provided DC_API_KEY is invalid or expired: {str(e)}\n"
+        )
+        sys.exit(1)
+    except Exception as e:
+        if strict_mode:
+            sys.stderr.write(
+                f"Error: DC_API_KEY verification unreachable and strict validation is enabled: {str(e)}\n"
+            )
+            sys.exit(1)
+        else:
+            logger.warning(
+                "Warning: DC_API_KEY verification unreachable. Starting in degraded mode: %s",
+                str(e),
+            )
+            os.environ["_DC_API_KEY_STARTUP_DEGRADED"] = "true"
+            os.environ["_DC_API_KEY_STATUS"] = "unverified"
 
 
 def cli_help() -> str:
@@ -63,6 +113,9 @@ def start(
         gcp_spanner_instance_id=gcp_spanner_instance_id,
         gcp_spanner_database_name=gcp_spanner_database_name,
     )
+
+    # Validate API key before running the server
+    validate_api_key_startup()
 
     logger.info("Starting API server...")
     uvicorn.run(

--- a/packages/datacommons-api/datacommons_api/app.py
+++ b/packages/datacommons-api/datacommons_api/app.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +14,12 @@
 
 """Main FastAPI application definition."""
 
-from fastapi import FastAPI, Request
+import asyncio
+import os
+from fastapi import FastAPI, Request, Response, status
 from fastapi.responses import JSONResponse
 from fastapi.openapi.utils import get_openapi
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from datacommons_api.endpoints.routers import node_router
@@ -25,6 +28,7 @@ from datacommons_api.core.exceptions import (
     APIKeyForbiddenError,
 )
 from datacommons_api.core.logging import get_logger
+from datacommons_api.services.central_api_client import CentralAPIClient
 from . import __version__
 
 logger = get_logger(__name__)
@@ -38,6 +42,79 @@ app = FastAPI(
     redoc_url="/redoc",
     debug=True,
 )
+
+# Initialize app state from inherited environment variables
+app.state.degraded = os.getenv("_DC_API_KEY_STARTUP_DEGRADED", "").lower() == "true"
+app.state.api_key_status = os.getenv("_DC_API_KEY_STATUS", "verified")
+app.state.api_key_consecutive_failures = 0
+app.state.api_key_outage_escalated = False
+
+
+async def periodic_key_recheck():
+    """Background task to periodically re-validate the API key if started degraded."""
+    api_key = os.getenv("DC_API_KEY", "").strip()
+    if not api_key:
+        return
+
+    client = CentralAPIClient(api_key=api_key)
+
+    while app.state.degraded and app.state.api_key_status in ("unverified", "invalid"):
+        await asyncio.sleep(60)  # Recheck every 1 minute
+
+        try:
+            # Run the synchronous HTTP check in a threadpool to keep it non-blocking
+            await run_in_threadpool(client.query_usa_population)
+
+            # Success! Reset state
+            app.state.degraded = False
+            app.state.api_key_status = "verified"
+            app.state.api_key_consecutive_failures = 0
+            app.state.api_key_outage_escalated = False
+
+            # Update env vars to sync with any new workers
+            os.environ["_DC_API_KEY_STARTUP_DEGRADED"] = "false"
+            os.environ["_DC_API_KEY_STATUS"] = "verified"
+
+            logger.info(
+                "DC_API_KEY successfully verified by background worker. Exiting degraded mode."
+            )
+            break  # Stop background worker
+        except (APIKeyUnauthorizedError, APIKeyForbiddenError) as e:
+            # Key is definitively invalid!
+            app.state.api_key_status = "invalid"
+            os.environ["_DC_API_KEY_STATUS"] = "invalid"
+            logger.critical(
+                "CRITICAL: Background validation confirmed the configured DC_API_KEY is invalid/expired: %s. "
+                "Please update configuration. Terminating background check.",
+                str(e),
+            )
+            break
+        except Exception as e:
+            # Network / DNS / 5xx outage
+            app.state.api_key_consecutive_failures += 1
+            logger.warning(
+                "DC_API_KEY background recheck failed (consecutive failures: %d): %s",
+                app.state.api_key_consecutive_failures,
+                str(e),
+            )
+
+            # 30-Minute Outage Escalation Policy
+            if (
+                app.state.api_key_consecutive_failures >= 30
+                and not app.state.api_key_outage_escalated
+            ):
+                app.state.api_key_outage_escalated = True
+                logger.critical(
+                    "CRITICAL: DC_API_KEY background validation has failed continuously for 30 minutes. "
+                    "Please check your network and API key configuration."
+                )
+
+
+@app.on_event("startup")
+async def startup_event():
+    """Spawn the background recheck task if server started in degraded mode."""
+    if app.state.degraded and app.state.api_key_status == "unverified":
+        asyncio.create_task(periodic_key_recheck())
 
 
 # Standardized error response model for OpenAPI documentation
@@ -97,6 +174,40 @@ async def api_key_forbidden_exception_handler(
     )
 
 
+# Health and Status Endpoints
+@app.get("/healthz", tags=["status"])
+@app.get("/status", tags=["status"], include_in_schema=False)
+def health_check(response: Response):
+    """Expose application health and API key validation status."""
+    degraded = app.state.degraded
+    api_key_status = app.state.api_key_status
+    outage_escalated = app.state.api_key_outage_escalated
+
+    # Case A: Critical / Unhealthy (Definitively invalid key or 30-min outage)
+    if api_key_status == "invalid" or outage_escalated:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return {
+            "status": "unhealthy",
+            "degraded": True,
+            "api_key_status": api_key_status,
+            "critical": True,
+            "message": "Data Commons API key validation has failed continuously. Spanner queries remain available.",
+        }
+
+    # Case B: Warning / Degraded (Network outage during startup, < 30 mins)
+    if degraded and api_key_status == "unverified":
+        return {
+            "status": "degraded",
+            "degraded": True,
+            "api_key_status": "unverified",
+            "critical": False,
+            "message": "Data Commons API key is unverified due to network issues. Operating in degraded fail-open mode.",
+        }
+
+    # Case C: Healthy (Verified or Bypassed)
+    return {"status": "healthy", "degraded": False, "api_key_status": api_key_status}
+
+
 # Override OpenAPI generator to document 401 & 403 globally
 def custom_openapi():
     if app.openapi_schema:
@@ -107,10 +218,12 @@ def custom_openapi():
         routes=app.routes,
     )
     # Add 401 and 403 responses to all routes except health checks
-    for path, methods in openapi_schema.get("paths", {}).items():
+    for path, path_item in openapi_schema.get("paths", {}).items():
         if path in ("/healthz", "/status"):
             continue
-        for method in methods.values():
+        for method in path_item.values():
+            if not isinstance(method, dict):
+                continue
             method.setdefault("responses", {})
             method["responses"]["401"] = {
                 "description": "Unauthorized - API Key is invalid or expired",

--- a/packages/datacommons-api/tests/test_api_cli_startup.py
+++ b/packages/datacommons-api/tests/test_api_cli_startup.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for CLI startup validation hook."""
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+import pytest
+
+from datacommons_api.core.exceptions import (
+    APIKeyUnauthorizedError,
+    APIKeyForbiddenError,
+)
+from datacommons_api.api_cli import validate_api_key_startup
+
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    """Ensure a clean environment for each test and restore it afterwards."""
+    old_env = dict(os.environ)
+    # Clear key environment variables
+    os.environ.pop("DC_API_KEY", None)
+    os.environ.pop("DC_API_KEY_OPTIONAL", None)
+    os.environ.pop("DC_API_KEY_STRICT_VALIDATION", None)
+    os.environ.pop("_DC_API_KEY_STARTUP_DEGRADED", None)
+    os.environ.pop("_DC_API_KEY_STATUS", None)
+    yield
+    os.environ.clear()
+    os.environ.update(old_env)
+
+
+def test_startup_success():
+    os.environ["DC_API_KEY"] = "valid-key"
+
+    with (
+        patch(
+            "datacommons_api.services.central_api_client.CentralAPIClient.query_usa_population"
+        ) as mock_query,
+        patch("sys.exit") as mock_exit,
+    ):
+        validate_api_key_startup()
+
+        mock_query.assert_called_once()
+        mock_exit.assert_not_called()
+        assert os.environ.get("_DC_API_KEY_STARTUP_DEGRADED") == "false"
+        assert os.environ.get("_DC_API_KEY_STATUS") == "verified"
+
+
+def test_startup_missing_key_fails():
+    with (
+        patch("sys.exit", side_effect=SystemExit) as mock_exit,
+        patch("sys.stderr.write") as mock_stderr,
+    ):
+        with pytest.raises(SystemExit):
+            validate_api_key_startup()
+
+        mock_exit.assert_called_once_with(1)
+        mock_stderr.assert_called_once_with(
+            "Error: DC_API_KEY environment variable is missing.\n"
+        )
+
+
+def test_startup_missing_key_bypassed():
+    os.environ["DC_API_KEY_OPTIONAL"] = "true"
+
+    with (
+        patch("sys.exit") as mock_exit,
+        patch(
+            "datacommons_api.services.central_api_client.CentralAPIClient.query_usa_population"
+        ) as mock_query,
+    ):
+        validate_api_key_startup()
+
+        mock_query.assert_not_called()
+        mock_exit.assert_not_called()
+        assert os.environ.get("_DC_API_KEY_STARTUP_DEGRADED") == "true"
+        assert os.environ.get("_DC_API_KEY_STATUS") == "bypassed"
+
+
+def test_startup_invalid_key_fails():
+    os.environ["DC_API_KEY"] = "invalid-key"
+
+    with (
+        patch(
+            "datacommons_api.services.central_api_client.CentralAPIClient.query_usa_population",
+            side_effect=APIKeyUnauthorizedError("Invalid or expired API key"),
+        ) as mock_query,
+        patch("sys.exit", side_effect=SystemExit) as mock_exit,
+        patch("sys.stderr.write") as mock_stderr,
+    ):
+        with pytest.raises(SystemExit):
+            validate_api_key_startup()
+
+        mock_query.assert_called_once()
+        mock_exit.assert_called_once_with(1)
+        assert (
+            "Error: Provided DC_API_KEY is invalid or expired"
+            in mock_stderr.call_args[0][0]
+        )
+
+
+def test_startup_unreachable_fail_open():
+    os.environ["DC_API_KEY"] = "valid-key"
+
+    with (
+        patch(
+            "datacommons_api.services.central_api_client.CentralAPIClient.query_usa_population",
+            side_effect=Exception("Connection timeout"),
+        ) as mock_query,
+        patch("sys.exit") as mock_exit,
+    ):
+        validate_api_key_startup()
+
+        mock_query.assert_called_once()
+        mock_exit.assert_not_called()
+        assert os.environ.get("_DC_API_KEY_STARTUP_DEGRADED") == "true"
+        assert os.environ.get("_DC_API_KEY_STATUS") == "unverified"
+
+
+def test_startup_unreachable_fail_closed():
+    os.environ["DC_API_KEY"] = "valid-key"
+    os.environ["DC_API_KEY_STRICT_VALIDATION"] = "true"
+
+    with (
+        patch(
+            "datacommons_api.services.central_api_client.CentralAPIClient.query_usa_population",
+            side_effect=Exception("Connection timeout"),
+        ) as mock_query,
+        patch("sys.exit", side_effect=SystemExit) as mock_exit,
+        patch("sys.stderr.write") as mock_stderr,
+    ):
+        with pytest.raises(SystemExit):
+            validate_api_key_startup()
+
+        mock_query.assert_called_once()
+        mock_exit.assert_called_once_with(1)
+        assert (
+            "Error: DC_API_KEY verification unreachable and strict validation is enabled"
+            in mock_stderr.call_args[0][0]
+        )

--- a/packages/datacommons-api/tests/test_background_worker.py
+++ b/packages/datacommons-api/tests/test_background_worker.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for background re-validation worker."""
+
+import os
+from unittest.mock import patch, MagicMock
+import pytest
+
+from datacommons_api.app import app, periodic_key_recheck
+from datacommons_api.core.exceptions import APIKeyUnauthorizedError
+
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    """Reset app state and environment before/after each test."""
+    old_env = dict(os.environ)
+    app.state.degraded = False
+    app.state.api_key_status = "verified"
+    app.state.api_key_consecutive_failures = 0
+    app.state.api_key_outage_escalated = False
+    os.environ.pop("DC_API_KEY", None)
+    os.environ.pop("_DC_API_KEY_STARTUP_DEGRADED", None)
+    os.environ.pop("_DC_API_KEY_STATUS", None)
+    yield
+    os.environ.clear()
+    os.environ.update(old_env)
+
+
+@pytest.mark.asyncio
+async def test_background_success_exits_degraded():
+    # Setup degraded state
+    app.state.degraded = True
+    app.state.api_key_status = "unverified"
+    os.environ["DC_API_KEY"] = "valid-key"
+
+    # Mock query to succeed
+    mock_query = MagicMock(return_value={"data": "ok"})
+
+    with (
+        patch(
+            "datacommons_api.services.central_api_client.CentralAPIClient.query_usa_population",
+            mock_query,
+        ),
+        patch("asyncio.sleep") as mock_sleep,
+    ):
+        # Loop will sleep once, then query, succeed, and exit.
+        # We don't need to force exit because success sets app.state.degraded = False,
+        # which breaks the loop.
+        mock_sleep.return_value = None
+
+        await periodic_key_recheck()
+
+        assert app.state.degraded is False
+        assert app.state.api_key_status == "verified"
+        assert os.environ.get("_DC_API_KEY_STARTUP_DEGRADED") == "false"
+        assert os.environ.get("_DC_API_KEY_STATUS") == "verified"
+        mock_query.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_background_auth_error_sets_invalid():
+    app.state.degraded = True
+    app.state.api_key_status = "unverified"
+    os.environ["DC_API_KEY"] = "invalid-key"
+
+    # Mock query to raise APIKeyUnauthorizedError
+    with (
+        patch(
+            "datacommons_api.services.central_api_client.CentralAPIClient.query_usa_population",
+            side_effect=APIKeyUnauthorizedError("Invalid"),
+        ),
+        patch("asyncio.sleep") as mock_sleep,
+    ):
+        mock_sleep.return_value = None
+
+        await periodic_key_recheck()
+
+        assert app.state.api_key_status == "invalid"
+        assert os.environ.get("_DC_API_KEY_STATUS") == "invalid"
+        mock_sleep.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_background_outage_escalates():
+    app.state.degraded = True
+    app.state.api_key_status = "unverified"
+    app.state.api_key_consecutive_failures = 0
+    app.state.api_key_outage_escalated = False
+    os.environ["DC_API_KEY"] = "valid-key"
+
+    # Mock query to raise a network exception
+    with (
+        patch(
+            "datacommons_api.services.central_api_client.CentralAPIClient.query_usa_population",
+            side_effect=Exception("Network error"),
+        ),
+        patch("asyncio.sleep") as mock_sleep,
+    ):
+        # We need the loop to run 30 times to trigger escalation.
+        # On the 30th sleep call, we force exit the loop.
+        iteration = 0
+
+        async def sleep_side_effect(secs):
+            nonlocal iteration
+            iteration += 1
+            if iteration >= 30:
+                app.state.degraded = False  # Force exit
+
+        mock_sleep.side_effect = sleep_side_effect
+
+        await periodic_key_recheck()
+
+        assert app.state.api_key_consecutive_failures >= 30
+        assert app.state.api_key_outage_escalated is True

--- a/packages/datacommons-api/tests/test_health_check.py
+++ b/packages/datacommons-api/tests/test_health_check.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for /healthz and /status endpoints."""
+
+from fastapi.testclient import TestClient
+import pytest
+
+from datacommons_api.app import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    """Reset app state before/after each test."""
+    app.state.degraded = False
+    app.state.api_key_status = "verified"
+    app.state.api_key_consecutive_failures = 0
+    app.state.api_key_outage_escalated = False
+    yield
+
+
+def test_health_healthy():
+    app.state.degraded = False
+    app.state.api_key_status = "verified"
+
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "healthy",
+        "degraded": False,
+        "api_key_status": "verified",
+    }
+
+    # Test alias `/status`
+    response_alias = client.get("/status")
+    assert response_alias.status_code == 200
+    assert response_alias.json() == response.json()
+
+
+def test_health_degraded_warning():
+    app.state.degraded = True
+    app.state.api_key_status = "unverified"
+    app.state.api_key_outage_escalated = False
+
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "degraded"
+    assert data["degraded"] is True
+    assert data["api_key_status"] == "unverified"
+    assert data["critical"] is False
+    assert "degraded fail-open mode" in data["message"]
+
+
+def test_health_unhealthy_invalid_key():
+    app.state.degraded = True
+    app.state.api_key_status = "invalid"
+
+    response = client.get("/healthz")
+    assert response.status_code == 503
+    data = response.json()
+    assert data["status"] == "unhealthy"
+    assert data["degraded"] is True
+    assert data["api_key_status"] == "invalid"
+    assert data["critical"] is True
+    assert "validation has failed continuously" in data["message"]
+
+
+def test_health_unhealthy_escalated_outage():
+    app.state.degraded = True
+    app.state.api_key_status = "unverified"
+    app.state.api_key_outage_escalated = True
+
+    response = client.get("/healthz")
+    assert response.status_code == 503
+    data = response.json()
+    assert data["status"] == "unhealthy"
+    assert data["degraded"] is True
+    assert data["api_key_status"] == "unverified"
+    assert data["critical"] is True
+    assert "validation has failed continuously" in data["message"]


### PR DESCRIPTION
**PR 3 of 3 (Stacked)**
* **Source**: `premr/api-key-startup-and-health`
* **Target**: `premr/api-key-error-propagation`

### 1. Context & Motivation (PRD)
To prevent silent runtime failures, we need a robust validation gate on startup. However, because local Spanner queries remain fully functional even without a central API connection, a transient network outage or DNS error during startup should not crash the server.

This PR implements the active CLI startup validation gate, Uvicorn process environment synchronization, a non-blocking 1-minute background recheck loop (Fail-Open), a 30-minute outage health degradation policy, and detailed `/healthz` diagnostics.

### 2. Key Changes
* **CLI Startup Gate (`datacommons_api/api_cli.py`)**:
  * Synchronously validates the key before port-binding.
  * Halts startup (`sys.exit(1)`) on definitive authentication failures, or when unreachable under strict mode (`DC_API_KEY_STRICT_VALIDATION=true`).
  * Graces network timeouts by starting degraded. Bypasses check if key is missing and `DC_API_KEY_OPTIONAL=true`.
  * Propagates boot state to Uvicorn worker child processes by setting inherited environment variables (`_DC_API_KEY_STARTUP_DEGRADED` and `_DC_API_KEY_STATUS`).
* **Background Worker & 30-Min Outage Escalation (`datacommons_api/app.py`)**:
  * Spawns `periodic_key_recheck` background task if started degraded, repinging the central API every 1 minute in a threadpool (safely non-blocking).
  * If failures persist continuously for 30 checks (30 minutes), it escalates the outage status to critical and logs a loud warning.
* **Health Diagnostics Endpoint (`datacommons_api/app.py`)**:
  * Registered `/healthz` (and hidden `/status` alias).
  * Returns `503 Service Unavailable` on confirmed invalid keys or 30-minute escalated outages, and `200 OK` warning when degraded but unverified.
* **Developer Diagnostics Documentation (`README.md`)**:
  * Meticulously documented all parameters, error JSON schemas, and health check diagnostics.

### 3. Verification & Tests
* Implemented `tests/test_api_cli_startup.py`, `tests/test_background_worker.py` (with elegant sleep mocking), and `tests/test_health_check.py`. All tests pass 100% cleanly.
