### PR TITLE
[DCP Workflow] No more mixer restarts after the ingestion workflow

### DIFF
--- a/infra/dcp/modules/ingestion/dataflow/main.tf
+++ b/infra/dcp/modules/ingestion/dataflow/main.tf
@@ -22,6 +22,7 @@ resource "google_project_iam_member" "dataflow_worker" {
   role    = "roles/dataflow.worker"
   member  = "serviceAccount:${google_service_account.dataflow_sa[0].email}"
 }
+
 data "google_project" "project" {
   project_id = var.project_id
 }

--- a/infra/dcp/modules/ingestion/dataflow/main.tf
+++ b/infra/dcp/modules/ingestion/dataflow/main.tf
@@ -22,16 +22,6 @@ resource "google_project_iam_member" "dataflow_worker" {
   role    = "roles/dataflow.worker"
   member  = "serviceAccount:${google_service_account.dataflow_sa[0].email}"
 }
-
-# This is only needed to trigger the services restart to pick up the GCS embeddings change
-
-resource "google_service_account_iam_member" "service_account_user" {
-  count              = var.deploy ? 1 : 0
-  service_account_id = google_service_account.dataflow_sa[0].name
-  role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${google_service_account.dataflow_sa[0].email}"
-}
-
 data "google_project" "project" {
   project_id = var.project_id
 }

--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -240,16 +240,6 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
           switch:
             - condition: '$${execution_error != null}'
               raise: '$${execution_error}'
-%{if var.enable_datacommons_services}
-      - restart_service:
-          call: googleapis.run.v2.projects.locations.services.patch
-          args:
-            name: "projects/${var.project_id}/locations/${var.region}/services/${local.name_prefix}dc-datacommons-service"
-            updateMask: "template.labels"
-            body:
-              template:
-                labels:
-                  restarted-at: '$${string(int(sys.now()))}'
 %{if var.enable_redis_cache_clearing}
       - clear_cache_step:
           call: http.post
@@ -258,7 +248,6 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
             auth:
               type: OIDC
           result: clear_cache_result
-%{endif}
 %{endif}
       - return_result:
           return: '$${launch_result}'
@@ -278,11 +267,4 @@ resource "google_cloud_run_v2_service_iam_member" "helper_invoker" {
   name     = var.ingestion_helper_service_name
   role     = "roles/run.invoker"
   member   = "serviceAccount:${google_service_account.workflow_sa[0].email}"
-}
-
-resource "google_project_iam_member" "workflow_run_viewer" {
-  count   = var.deploy ? 1 : 0
-  project = var.project_id
-  role    = "roles/run.viewer"
-  member  = "serviceAccount:${google_service_account.workflow_sa[0].email}"
 }

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -47,12 +47,6 @@ variable "embeddings_timeout" {
   default     = 1800
 }
 
-variable "enable_datacommons_services" {
-  type        = bool
-  description = "Flag to indicate if datacommons_services is enabled"
-  default     = true
-}
-
 variable "ingestion_helper_service_name" {
   type        = string
   description = "Name of the ingestion helper Cloud Run service"

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -297,6 +297,30 @@ resource "google_storage_bucket_iam_member" "preprocessing_bucket_access" {
   member = "serviceAccount:${module.ingestion_preprocessing_job[0].service_account_email}"
 }
 
+resource "google_cloud_run_v2_job_iam_member" "workflow_pre_viewer" {
+  count    = var.ingestion_config.enable_ingestion ? 1 : 0
+  location = var.global.region
+  name     = module.ingestion_preprocessing_job[0].job_name
+  role     = "roles/run.viewer"
+  member   = "serviceAccount:${module.ingestion_workflow.service_account_email}"
+}
+
+resource "google_cloud_run_v2_job_iam_member" "workflow_pre_invoker" {
+  count    = var.ingestion_config.enable_ingestion ? 1 : 0
+  location = var.global.region
+  name     = module.ingestion_preprocessing_job[0].job_name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${module.ingestion_workflow.service_account_email}"
+}
+
+resource "google_cloud_run_v2_job_iam_member" "workflow_pre_developer" {
+  count    = var.ingestion_config.enable_ingestion ? 1 : 0
+  location = var.global.region
+  name     = module.ingestion_preprocessing_job[0].job_name
+  role     = "roles/run.developer"
+  member   = "serviceAccount:${module.ingestion_workflow.service_account_email}"
+}
+
 resource "google_project_iam_member" "workflow_dataflow_developer" {
   count   = var.ingestion_config.enable_ingestion ? 1 : 0
   project = var.global.project_id

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -194,7 +194,6 @@ module "ingestion_workflow" {
   dataflow_service_account_email = module.ingestion_dataflow.service_account_email
   enable_bigquery_postprocessing = var.ingestion_config.workflow_enable_bigquery_postprocessing
   enable_embeddings_generation   = var.spanner_config.enable_embeddings_generation
-  enable_datacommons_services    = var.datacommons_services_config.enable
   ingestion_helper_service_name  = "${var.global.namespace != "" ? "${var.global.namespace}-" : ""}dc-ingestion-helper"
   enable_redis_cache_clearing    = var.redis_config.enable
   ingestion_artifacts_path       = "${var.ingestion_config.ingestion_artifacts_path}/metadata"
@@ -290,27 +289,9 @@ resource "google_storage_bucket_iam_member" "dataflow_bucket_access" {
   member = "serviceAccount:${module.ingestion_dataflow.service_account_email}"
 }
 
-# This is only needed to trigger the services restart to pick up the GCS embeddings change
-# Mandatory dependency: The Ingestion Workflow service account needs to act as the Serving service account
-# to perform the service restart step via the Cloud Run API after ingestion completes.
-resource "google_service_account_iam_member" "ingestion_workflow_act_as_serving_sa" {
-  count              = var.ingestion_config.enable_ingestion && var.datacommons_services_config.enable ? 1 : 0
-  service_account_id = "projects/${var.global.project_id}/serviceAccounts/${module.datacommons_services[0].service_account_email}"
-  role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${module.ingestion_workflow.service_account_email}"
-}
 
 
 
-resource "google_spanner_database_iam_member" "workflow_spanner_user" {
-  # Only create if ingestion is enabled and Spanner is enabled!
-  count = var.ingestion_config.enable_ingestion && var.spanner_config.enable ? 1 : 0
-  # Use index [0] because module.spanner is conditional.
-  instance = module.spanner[0].spanner_instance_id
-  database = module.spanner[0].spanner_database_id
-  role     = "roles/spanner.databaseUser"
-  member   = "serviceAccount:${module.ingestion_workflow.service_account_email}"
-}
 
 
 
@@ -321,29 +302,7 @@ resource "google_storage_bucket_iam_member" "workflow_bucket_access" {
   member = "serviceAccount:${module.ingestion_workflow.service_account_email}"
 }
 
-resource "google_cloud_run_v2_job_iam_member" "workflow_pre_viewer" {
-  count    = var.ingestion_config.enable_ingestion ? 1 : 0
-  location = var.global.region
-  name     = module.ingestion_preprocessing_job[0].job_name
-  role     = "roles/run.viewer"
-  member   = "serviceAccount:${module.ingestion_workflow.service_account_email}"
-}
 
-resource "google_cloud_run_v2_job_iam_member" "workflow_pre_invoker" {
-  count    = var.ingestion_config.enable_ingestion ? 1 : 0
-  location = var.global.region
-  name     = module.ingestion_preprocessing_job[0].job_name
-  role     = "roles/run.invoker"
-  member   = "serviceAccount:${module.ingestion_workflow.service_account_email}"
-}
-
-resource "google_cloud_run_v2_job_iam_member" "workflow_pre_developer" {
-  count    = var.ingestion_config.enable_ingestion ? 1 : 0
-  location = var.global.region
-  name     = module.ingestion_preprocessing_job[0].job_name
-  role     = "roles/run.developer"
-  member   = "serviceAccount:${module.ingestion_workflow.service_account_email}"
-}
 
 resource "google_storage_bucket_iam_member" "preprocessing_bucket_access" {
   count  = var.ingestion_config.enable_ingestion ? 1 : 0
@@ -361,13 +320,6 @@ resource "google_project_iam_member" "workflow_dataflow_developer" {
   member  = "serviceAccount:${module.ingestion_workflow.service_account_email}"
 }
 
-resource "google_cloud_run_v2_service_iam_member" "workflow_serving_developer" {
-  count    = var.ingestion_config.enable_ingestion && var.datacommons_services_config.enable ? 1 : 0
-  location = var.global.region
-  name     = module.datacommons_services[0].service_name
-  role     = "roles/run.developer"
-  member   = "serviceAccount:${module.ingestion_workflow.service_account_email}"
-}
 
 
 

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -101,7 +101,6 @@ module "spanner" {
   bigquery_reservation_max_slots     = var.spanner_config.bigquery_reservation_max_slots
 }
 
-
 module "storage" {
   source = "../storage"
 
@@ -153,7 +152,6 @@ module "ingestion_dataflow" {
   use_spanner           = var.spanner_config.enable
 }
 
-
 module "ingestion_helper_service" {
   source = "../ingestion/helper_service"
 
@@ -203,8 +201,6 @@ module "ingestion_workflow" {
 
   depends_on = [module.ingestion_helper_service]
 }
-
-
 
 module "redis" {
   source = "../redis"
@@ -276,8 +272,6 @@ check "datacommons_api_key_provided" {
 }
 
 
-
-
 # =============================================================================
 # Cross-Module IAM Bindings
 # =============================================================================
@@ -289,20 +283,12 @@ resource "google_storage_bucket_iam_member" "dataflow_bucket_access" {
   member = "serviceAccount:${module.ingestion_dataflow.service_account_email}"
 }
 
-
-
-
-
-
-
 resource "google_storage_bucket_iam_member" "workflow_bucket_access" {
   count  = var.ingestion_config.enable_ingestion ? 1 : 0
   bucket = module.storage.artifacts_bucket_name
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${module.ingestion_workflow.service_account_email}"
 }
-
-
 
 resource "google_storage_bucket_iam_member" "preprocessing_bucket_access" {
   count  = var.ingestion_config.enable_ingestion ? 1 : 0
@@ -311,17 +297,9 @@ resource "google_storage_bucket_iam_member" "preprocessing_bucket_access" {
   member = "serviceAccount:${module.ingestion_preprocessing_job[0].service_account_email}"
 }
 
-
-
 resource "google_project_iam_member" "workflow_dataflow_developer" {
   count   = var.ingestion_config.enable_ingestion ? 1 : 0
   project = var.global.project_id
   role    = "roles/dataflow.developer"
   member  = "serviceAccount:${module.ingestion_workflow.service_account_email}"
 }
-
-
-
-
-
-


### PR DESCRIPTION
This was required for GCS embeddings to be picked up, but is no longer necessary