### PR TITLE
fix: handle when dataflow template gcs path points to `latest` but `latest` doesn't get refreshed

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -59,6 +59,9 @@ resource "google_project_service" "apis" {
 }
 
 locals {
+  # Redirect abandoned 'latest' alias to 'stable' for Dataflow templates
+  df_template_version = var.dcp_version == "latest" ? "stable" : var.dcp_version
+
   global_config = {
     project_id                    = var.project_id
     region                        = var.region
@@ -140,7 +143,7 @@ locals {
     # Dataflow Network Configuration
     dataflow_ip_configuration     = var.ingestion_dataflow_ip_configuration
     dataflow_subnetwork           = var.ingestion_dataflow_subnetwork
-    dataflow_template_gcs_path    = coalesce(var.ingestion_dataflow_template_gcs_path, "gs://datcom-templates/templates/flex/ingestion-${var.dcp_version}.json")
+    dataflow_template_gcs_path    = coalesce(var.ingestion_dataflow_template_gcs_path, "gs://datcom-templates/templates/flex/ingestion-${local.df_template_version}.json")
   }
 }
 


### PR DESCRIPTION
we should actually remove the latest template because it's not getting updated, but will do this fallback since all the other versioning have `latest` tag.