### PR TITLE
fix(terraform): add depends_on for secrets accessor in preprocessing job

### DIFF
--- a/infra/dcp/modules/ingestion/preprocessing_job/main.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/main.tf
@@ -107,6 +107,7 @@ EOT
 }
 
 resource "google_secret_manager_secret_iam_member" "preprocessing_api_key_accessor" {
+  count     = var.dc_api_key_secret_id != "" ? 1 : 0
   project   = var.project_id
   secret_id = var.dc_api_key_secret_id
   role      = "roles/secretmanager.secretAccessor"
@@ -114,6 +115,7 @@ resource "google_secret_manager_secret_iam_member" "preprocessing_api_key_access
 }
 
 resource "google_secret_manager_secret_iam_member" "preprocessing_maps_key_accessor" {
+  count     = var.maps_api_key_secret_id != "" ? 1 : 0
   project   = var.project_id
   secret_id = var.maps_api_key_secret_id
   role      = "roles/secretmanager.secretAccessor"

--- a/infra/dcp/modules/ingestion/preprocessing_job/main.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/main.tf
@@ -36,9 +36,9 @@ resource "google_cloud_run_v2_job" "dc_data_job" {
         }
 
         dynamic "env" {
-          for_each = { for k, v in var.secrets : k => v if v.enabled }
+          for_each = { for s in var.secrets : s.name => s if s.enabled }
           content {
-            name = upper(env.key)
+            name = env.key
             value_source {
               secret_key_ref {
                 secret  = env.value.secret_id
@@ -106,7 +106,7 @@ EOT
 }
 
 resource "google_secret_manager_secret_iam_member" "preprocessing_secret_accessor" {
-  for_each = { for k, v in var.secrets : k => v if v.enabled }
+  for_each = { for s in var.secrets : s.name => s if s.enabled }
 
   project   = var.project_id
   secret_id = each.value.secret_id

--- a/infra/dcp/modules/ingestion/preprocessing_job/main.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/main.tf
@@ -36,7 +36,7 @@ resource "google_cloud_run_v2_job" "dc_data_job" {
         }
 
         dynamic "env" {
-          for_each = { for s in var.secrets : s.name => s if s.enabled }
+          for_each = { for k, v in var.env_secrets : k => v if v.enabled && v.secret_id != null && v.secret_id != "" }
           content {
             name = env.key
             value_source {
@@ -106,7 +106,7 @@ EOT
 }
 
 resource "google_secret_manager_secret_iam_member" "preprocessing_secret_accessor" {
-  for_each = { for s in var.secrets : s.name => s if s.enabled }
+  for_each = { for k, v in var.env_secrets : k => v if v.enabled && v.secret_id != null && v.secret_id != "" }
 
   project   = var.project_id
   secret_id = each.value.secret_id

--- a/infra/dcp/modules/ingestion/preprocessing_job/main.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/main.tf
@@ -12,6 +12,11 @@ resource "google_cloud_run_v2_job" "dc_data_job" {
   location            = var.region
   deletion_protection = var.stateless_deletion_protection
 
+  depends_on = [
+    google_secret_manager_secret_iam_member.preprocessing_api_key_accessor,
+    google_secret_manager_secret_iam_member.preprocessing_maps_key_accessor
+  ]
+
   template {
     template {
       containers {

--- a/infra/dcp/modules/ingestion/preprocessing_job/main.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/main.tf
@@ -13,8 +13,7 @@ resource "google_cloud_run_v2_job" "dc_data_job" {
   deletion_protection = var.stateless_deletion_protection
 
   depends_on = [
-    google_secret_manager_secret_iam_member.preprocessing_api_key_accessor,
-    google_secret_manager_secret_iam_member.preprocessing_maps_key_accessor
+    google_secret_manager_secret_iam_member.preprocessing_secret_accessor
   ]
 
   template {
@@ -37,13 +36,13 @@ resource "google_cloud_run_v2_job" "dc_data_job" {
         }
 
         dynamic "env" {
-          for_each = var.secret_env_vars
+          for_each = { for k, v in var.secrets : k => v if v.enabled }
           content {
-            name = env.value.name
+            name = upper(env.key)
             value_source {
               secret_key_ref {
-                secret  = env.value.secret
-                version = env.value.version
+                secret  = env.value.secret_id
+                version = "latest"
               }
             }
           }
@@ -106,18 +105,11 @@ EOT
   }
 }
 
-resource "google_secret_manager_secret_iam_member" "preprocessing_api_key_accessor" {
-  count     = (var.dc_api_key_secret_id != null && var.dc_api_key_secret_id != "") ? 1 : 0
-  project   = var.project_id
-  secret_id = var.dc_api_key_secret_id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.preprocessing_sa.email}"
-}
+resource "google_secret_manager_secret_iam_member" "preprocessing_secret_accessor" {
+  for_each = { for k, v in var.secrets : k => v if v.enabled }
 
-resource "google_secret_manager_secret_iam_member" "preprocessing_maps_key_accessor" {
-  count     = (var.maps_api_key_secret_id != null && var.maps_api_key_secret_id != "") ? 1 : 0
   project   = var.project_id
-  secret_id = var.maps_api_key_secret_id
+  secret_id = each.value.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.preprocessing_sa.email}"
 }

--- a/infra/dcp/modules/ingestion/preprocessing_job/main.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/main.tf
@@ -107,7 +107,7 @@ EOT
 }
 
 resource "google_secret_manager_secret_iam_member" "preprocessing_api_key_accessor" {
-  count     = var.dc_api_key_secret_id != "" ? 1 : 0
+  count     = (var.dc_api_key_secret_id != null && var.dc_api_key_secret_id != "") ? 1 : 0
   project   = var.project_id
   secret_id = var.dc_api_key_secret_id
   role      = "roles/secretmanager.secretAccessor"
@@ -115,7 +115,7 @@ resource "google_secret_manager_secret_iam_member" "preprocessing_api_key_access
 }
 
 resource "google_secret_manager_secret_iam_member" "preprocessing_maps_key_accessor" {
-  count     = var.maps_api_key_secret_id != "" ? 1 : 0
+  count     = (var.maps_api_key_secret_id != null && var.maps_api_key_secret_id != "") ? 1 : 0
   project   = var.project_id
   secret_id = var.maps_api_key_secret_id
   role      = "roles/secretmanager.secretAccessor"

--- a/infra/dcp/modules/ingestion/preprocessing_job/main.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/main.tf
@@ -42,7 +42,7 @@ resource "google_cloud_run_v2_job" "dc_data_job" {
             value_source {
               secret_key_ref {
                 secret  = env.value.secret_id
-                version = "latest"
+                version = env.value.version
               }
             }
           }

--- a/infra/dcp/modules/ingestion/preprocessing_job/main.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/main.tf
@@ -36,7 +36,7 @@ resource "google_cloud_run_v2_job" "dc_data_job" {
         }
 
         dynamic "env" {
-          for_each = { for k, v in var.env_secrets : k => v if v.enabled && v.secret_id != null && v.secret_id != "" }
+          for_each = { for k, v in var.env_secrets : k => v if v.enabled }
           content {
             name = env.key
             value_source {
@@ -106,7 +106,7 @@ EOT
 }
 
 resource "google_secret_manager_secret_iam_member" "preprocessing_secret_accessor" {
-  for_each = { for k, v in var.env_secrets : k => v if v.enabled && v.secret_id != null && v.secret_id != "" }
+  for_each = { for k, v in var.env_secrets : k => v if v.enabled }
 
   project   = var.project_id
   secret_id = each.value.secret_id

--- a/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
@@ -31,6 +31,7 @@ variable "env_secrets" {
   type = map(object({
     secret_id = string
     enabled   = bool
+    version   = optional(string, "latest")
   }))
   default     = {}
   description = <<-EOT
@@ -40,6 +41,7 @@ variable "env_secrets" {
       "DC_API_KEY" = {
         secret_id = "projects/my-project/secrets/my-secret"
         enabled   = true
+        version   = "latest" # Optional, defaults to "latest"
       }
     }
   EOT

--- a/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
@@ -27,23 +27,21 @@ variable "env_vars" {
   }))
 }
 
-variable "secrets" {
-  type = list(object({
-    name      = string
+variable "env_secrets" {
+  type = map(object({
     secret_id = string
     enabled   = bool
   }))
-  default     = []
+  default     = {}
   description = <<-EOT
-    List of secrets to grant access to and mount in the job.
+    Map of secrets to grant access to and mount in the job, where the key is the environment variable name.
     Example:
-    [
-      {
-        name      = "DC_API_KEY"
+    {
+      "DC_API_KEY" = {
         secret_id = "projects/my-project/secrets/my-secret"
         enabled   = true
       }
-    ]
+    }
   EOT
 }
 

--- a/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
@@ -33,7 +33,16 @@ variable "secrets" {
     enabled   = bool
   }))
   default     = {}
-  description = "Map of secrets to grant access to and mount in the job"
+  description = <<EOT
+Map of secrets to grant access to and mount in the job.
+Example:
+{
+  dc_api_key = {
+    secret_id = "projects/my-project/secrets/my-secret"
+    enabled   = true
+  }
+}
+EOT
 }
 
 variable "enable_spanner_embeddings" {

--- a/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
@@ -28,21 +28,23 @@ variable "env_vars" {
 }
 
 variable "secrets" {
-  type = map(object({
+  type = list(object({
+    name      = string
     secret_id = string
     enabled   = bool
   }))
-  default     = {}
-  description = <<EOT
-Map of secrets to grant access to and mount in the job.
-Example:
-{
-  dc_api_key = {
-    secret_id = "projects/my-project/secrets/my-secret"
-    enabled   = true
-  }
-}
-EOT
+  default     = []
+  description = <<-EOT
+    List of secrets to grant access to and mount in the job.
+    Example:
+    [
+      {
+        name      = "DC_API_KEY"
+        secret_id = "projects/my-project/secrets/my-secret"
+        enabled   = true
+      }
+    ]
+  EOT
 }
 
 variable "enable_spanner_embeddings" {

--- a/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
@@ -27,24 +27,13 @@ variable "env_vars" {
   }))
 }
 
-variable "secret_env_vars" {
-  type = list(object({
-    name    = string
-    secret  = string
-    version = string
+variable "secrets" {
+  type = map(object({
+    secret_id = string
+    enabled   = bool
   }))
-}
-
-variable "dc_api_key_secret_id" {
-  type        = string
-  description = "Secret ID for Data Commons API key"
-  default     = ""
-}
-
-variable "maps_api_key_secret_id" {
-  type        = string
-  description = "Secret ID for Maps API key"
-  default     = ""
+  default     = {}
+  description = "Map of secrets to grant access to and mount in the job"
 }
 
 variable "enable_spanner_embeddings" {

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -130,16 +130,18 @@ module "ingestion_preprocessing_job" {
   use_spanner                   = true
   enable_spanner_embeddings     = var.datacommons_services_config.resolve_with_spanner_embeddings
   env_vars                      = local.cloud_run_shared_env_variables
-  secrets = {
-    dc_api_key = {
+  secrets = [
+    {
+      name      = "DC_API_KEY"
       secret_id = module.auth.dc_api_key_secret_id
       enabled   = var.datacommons_services_config.enable
-    }
-    maps_api_key = {
+    },
+    {
+      name      = "MAPS_API_KEY"
       secret_id = module.auth.maps_api_key_secret_id
       enabled   = var.datacommons_services_config.enable && !var.datacommons_services_config.website_disable_google_maps_api && (var.auth_config.google_maps_api_key != null || var.auth_config.create_google_maps_key)
     }
-  }
+  ]
 
   depends_on = [module.auth]
 }

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -137,7 +137,7 @@ module "ingestion_preprocessing_job" {
     }
     MAPS_API_KEY = {
       secret_id = module.auth.maps_api_key_secret_id
-      enabled   = true
+      enabled   = var.auth_config.google_maps_api_key != null || var.auth_config.create_google_maps_key
     }
   }
 

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -73,8 +73,6 @@ locals {
       version = "latest"
     }
   ] : []) : []
-
-  enable_preprocessing_maps_api = module.auth.maps_api_key_secret_id != null && module.auth.maps_api_key_secret_id != ""
 }
 
 module "spanner" {
@@ -135,11 +133,11 @@ module "ingestion_preprocessing_job" {
   env_secrets = {
     DC_API_KEY = {
       secret_id = module.auth.dc_api_key_secret_id
-      enabled   = module.auth.dc_api_key_secret_id != null && module.auth.dc_api_key_secret_id != ""
+      enabled   = true
     }
     MAPS_API_KEY = {
       secret_id = module.auth.maps_api_key_secret_id
-      enabled   = local.enable_preprocessing_maps_api
+      enabled   = true
     }
   }
 

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -130,9 +130,16 @@ module "ingestion_preprocessing_job" {
   use_spanner                   = true
   enable_spanner_embeddings     = var.datacommons_services_config.resolve_with_spanner_embeddings
   env_vars                      = local.cloud_run_shared_env_variables
-  secret_env_vars               = local.datacommons_services_secrets
-  dc_api_key_secret_id          = module.auth.dc_api_key_secret_id
-  maps_api_key_secret_id        = module.auth.maps_api_key_secret_id
+  secrets = {
+    dc_api_key = {
+      secret_id = module.auth.dc_api_key_secret_id
+      enabled   = var.datacommons_services_config.enable
+    }
+    maps_api_key = {
+      secret_id = module.auth.maps_api_key_secret_id
+      enabled   = var.datacommons_services_config.enable && !var.datacommons_services_config.website_disable_google_maps_api && (var.auth_config.google_maps_api_key != null || var.auth_config.create_google_maps_key)
+    }
+  }
 
   depends_on = [module.auth]
 }

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -134,7 +134,7 @@ module "ingestion_preprocessing_job" {
     {
       name      = "DC_API_KEY"
       secret_id = module.auth.dc_api_key_secret_id
-      enabled   = var.datacommons_services_config.enable
+      enabled   = true
     },
     {
       name      = "MAPS_API_KEY"

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -73,6 +73,8 @@ locals {
       version = "latest"
     }
   ] : []) : []
+
+  enable_preprocessing_maps_api = module.auth.maps_api_key_secret_id != null && module.auth.maps_api_key_secret_id != ""
 }
 
 module "spanner" {
@@ -130,18 +132,16 @@ module "ingestion_preprocessing_job" {
   use_spanner                   = true
   enable_spanner_embeddings     = var.datacommons_services_config.resolve_with_spanner_embeddings
   env_vars                      = local.cloud_run_shared_env_variables
-  secrets = [
-    {
-      name      = "DC_API_KEY"
+  env_secrets = {
+    DC_API_KEY = {
       secret_id = module.auth.dc_api_key_secret_id
-      enabled   = true
-    },
-    {
-      name      = "MAPS_API_KEY"
-      secret_id = module.auth.maps_api_key_secret_id
-      enabled   = var.datacommons_services_config.enable && !var.datacommons_services_config.website_disable_google_maps_api && (var.auth_config.google_maps_api_key != null || var.auth_config.create_google_maps_key)
+      enabled   = module.auth.dc_api_key_secret_id != null && module.auth.dc_api_key_secret_id != ""
     }
-  ]
+    MAPS_API_KEY = {
+      secret_id = module.auth.maps_api_key_secret_id
+      enabled   = local.enable_preprocessing_maps_api
+    }
+  }
 
   depends_on = [module.auth]
 }


### PR DESCRIPTION
### Problem
1. **Deployment Race Condition**: The Cloud Run preprocessing job creation occasionally failed with a `Permission denied` error because Terraform attempted to create the job and its Secret Manager IAM permissions in parallel.
2. **Plan-Time Evaluation Failure**: When Google Maps was disabled, we wanted to skip creating its IAM accessor. However, making it conditional using `count = var.secret_id != ""` broke `terraform plan` on clean deployments because the secret IDs (outputs from the `auth` module) were unknown at plan time.
3. **Missing DC API Key**: The preprocessing job was incorrectly using `var.datacommons_services_config.enable` to determine if it should mount `DC_API_KEY`. If serving services were disabled but ingestion was enabled, the job would run without the API key and fail.

### Solution
1. **Explicit Dependency**: Added `depends_on` to the Cloud Run job to ensure the IAM accessor permissions are applied first.
2. **Refactored Secrets Passing**: Refactored the `preprocessing_job` module to accept a list of secrets with explicit names and `enabled` flags (`var.secrets`). 
3. **Plan-Time Count Resolution**: Used `for_each` (filtered by the plan-time knowable `enabled` boolean) to conditionally create IAM accessors and mount secrets, resolving the plan-time errors.
4. **Always Enable DC API Key**: Set `enabled = true` for `DC_API_KEY` in the module call to ensure the preprocessing job always has access to it.
