### PR TITLE
fix(ingestion): grant roles/dataflow.viewer to ingestion helper service account

### DIFF
--- a/infra/dcp/modules/ingestion/helper_service/main.tf
+++ b/infra/dcp/modules/ingestion/helper_service/main.tf
@@ -129,6 +129,14 @@ resource "google_bigquery_connection_iam_member" "helper_connection_user" {
   member        = "serviceAccount:${google_service_account.helper_sa[0].email}"
 }
 
+resource "google_project_iam_member" "helper_dataflow_viewer" {
+  count   = var.deploy ? 1 : 0
+  project = var.project_id
+  role    = "roles/dataflow.viewer"
+  member  = "serviceAccount:${google_service_account.helper_sa[0].email}"
+}
+
+
 
 
 


### PR DESCRIPTION
The ingestion helper service account needs roles/dataflow.viewer to query Dataflow jobs for counts and execution time. Without this, ingestion metrics (NodeCount, EdgeCount, ObservationCount, ExecutionTime) in IngestionHistory and ImportVersionHistory tables remain at 0 due to 403 Permission Denied errors when calling the Dataflow API.

TAG=agy
CONV=864b2b62-6ccd-4640-86e2-61d312cc3a6e