### PR TITLE
fix(ingestion): align aggregation import list casing with preprocessor handshake

### DIFF
--- a/infra/dcp/modules/ingestion/workflow/workflow.yaml
+++ b/infra/dcp/modules/ingestion/workflow/workflow.yaml
@@ -120,6 +120,8 @@ main:
     - update_launch_params:
         assign:
           - launch_params.importList: '$${handshake_data.importList}'
+          - decoded_imports: '$${json.decode(handshake_data.importList)}'
+
 
     - try_acquire_lock:
         try:


### PR DESCRIPTION
## Description
This PR updates the ingestion workflow to decode the `importList` from the preprocessor's `handshake.json` file and propagate it to the aggregation service. 

Currently, the workflow passes the raw input folder names (e.g., `frog_data`) to the aggregation service. However, the preprocessor writes data to Spanner using case-preserved Provenance IDs (e.g., `provenance/FrogCensus`). This mismatch causes the aggregation generators (like `ProvenanceSummaryGenerator`) to match 0 rows, resulting in empty Cache tables.

By decoding and using the `importList` from the handshake file, we ensure the aggregation service queries Spanner using the correct case-preserved Provenance IDs.

Co-requisite: https://github.com/datacommonsorg/import/pull/636