### PR TITLE
infra/dcp: set default spanner processing units to 100

### DIFF
--- a/infra/dcp/modules/spanner/variables.tf
+++ b/infra/dcp/modules/spanner/variables.tf
@@ -30,7 +30,8 @@ variable "database_id" {
 }
 
 variable "processing_units" {
-  type = number
+  type    = number
+  default = 100
 }
 
 variable "stateful_deletion_protection" {

--- a/infra/dcp/modules/spanner/variables.tf
+++ b/infra/dcp/modules/spanner/variables.tf
@@ -30,8 +30,9 @@ variable "database_id" {
 }
 
 variable "processing_units" {
-  type    = number
-  default = 100
+  type     = number
+  default  = 100
+  nullable = false
 }
 
 variable "stateful_deletion_protection" {

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -25,7 +25,7 @@ variable "spanner_config" {
     instance_id                        = string
     database_id                        = string
     version_retention_period           = string
-    processing_units                   = number
+    processing_units                   = optional(number)
     enable_bigquery_connection         = bool
     enable_embeddings_generation       = bool
     bigquery_connection_name           = string

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -186,7 +186,7 @@ variable "spanner_version_retention_period" {
 }
 
 variable "spanner_processing_units" {
-  description = "Compute capacity for the Spanner instance in processing units (1000 = 1 node)"
+  description = "Compute capacity for the Spanner instance in processing units (1000 = 1 node). Defaults to 100 if not specified."
   type        = number
   default     = null
 }

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -188,7 +188,7 @@ variable "spanner_version_retention_period" {
 variable "spanner_processing_units" {
   description = "Compute capacity for the Spanner instance in processing units (1000 = 1 node)"
   type        = number
-  default     = 1000
+  default     = null
 }
 
 variable "spanner_enable_bigquery_connection" {


### PR DESCRIPTION
Defines the default value of 100 for processing_units in the spanner sub-module variables. Makes the processing_units attribute optional in the stack module's spanner_config. Sets the default for spanner_processing_units in the top-level variables.tf to null.