### PR TITLE
infra: propagate custom timeouts to Cloud Workflows preprocessing and postprocessing steps

### DIFF
--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -30,7 +30,11 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
     dataflow_ip_configuration      = var.dataflow_ip_configuration
     dataflow_subnetwork            = var.dataflow_subnetwork
     embeddings_timeout             = var.embeddings_timeout
+    preprocessing_job_timeout      = var.preprocessing_job_timeout
+    postprocessing_job_timeout     = var.postprocessing_job_timeout
     clean_namespace_prefix         = local.clean_namespace_prefix
+
+
     enable_redis_cache_clearing    = var.enable_redis_cache_clearing
     preprocessing_job_name         = var.preprocessing_job_name
     postprocessing_job_name        = var.postprocessing_job_name

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -47,6 +47,20 @@ variable "embeddings_timeout" {
   default     = 1800
 }
 
+variable "preprocessing_job_timeout" {
+  type        = number
+  description = "Timeout in seconds for the preprocessing Cloud Run job execution"
+  default     = 21600
+}
+
+variable "postprocessing_job_timeout" {
+  type        = number
+  description = "Timeout in seconds for the postprocessing Cloud Run job execution"
+  default     = 21600
+}
+
+
+
 variable "ingestion_helper_service_name" {
   type        = string
   description = "Name of the ingestion helper Cloud Run service"

--- a/infra/dcp/modules/ingestion/workflow/workflow.yaml
+++ b/infra/dcp/modules/ingestion/workflow/workflow.yaml
@@ -386,7 +386,10 @@ run_postprocessing_job:
                     - "--import_list"
                     - '$${json.encode_to_string(import_list)}'
                     - "--no-dry_run"
+          connector_params:
+            timeout: ${postprocessing_job_timeout}
         result: run_res
+
     - call_poll_postprocessing:
         call: poll_cloud_run_job_execution
         args:
@@ -520,7 +523,11 @@ launch_and_poll_preprocessing_job:
                     - name: 'DATA_RUN_MODE'
                       value: 'dcpbridge'
                   args: '$${container_args}'
+          connector_params:
+            timeout: ${preprocessing_job_timeout}
         result: run_res
+
+
 
     - assign_execution_name:
         assign:

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -224,9 +224,12 @@ module "ingestion_workflow" {
   dataflow_template_gcs_path     = var.ingestion_config.dataflow_template_gcs_path
   preprocessing_job_name         = var.ingestion_config.enable_ingestion ? module.ingestion_preprocessing_job[0].job_name : ""
   postprocessing_job_name        = var.ingestion_config.enable_ingestion ? module.ingestion_postprocessing_job[0].job_name : ""
+  preprocessing_job_timeout      = tonumber(replace(var.ingestion_config.preprocessing_job_timeout, "s", ""))
+  postprocessing_job_timeout     = tonumber(replace(var.ingestion_config.postprocessing_job_timeout, "s", ""))
 
   depends_on = [module.ingestion_helper_service]
 }
+
 
 module "redis" {
   source = "../redis"


### PR DESCRIPTION
This change exposes and propagates user-defined timeouts (`ingestion_preprocessing_job_timeout` and `ingestion_postprocessing_job_timeout`) from the stack infrastructure variables down to the Google Cloud Workflows orchestrator steps.

### Problem
Large dataset ingestions can exceed the default 30-minute (1800s) Google Cloud Workflows connector polling limit for long-running operations (LROs). Although custom timeouts are defined in the stack configuration, they were not being forwarded to the workflow definition. Consequently, the workflow orchestrator prematurely timed out with a `TimeoutError` during operation status polling, even when the underlying Cloud Run jobs were running correctly.

### Solution
*   **Variable Propagation:** Passed the timeout parameters down from `module.stack` to `module.ingestion_workflow`.
*   **Template Mapping:** Added timeout variables to the workflow YAML `templatefile` inside `modules/ingestion/workflow/main.tf`.
*   **Workflow Integration:** Configured the `timeout` parameter inside the `connector_params` block for both `run_cloud_run_job` (preprocessing) and `run_cloud_run_agg_job` (postprocessing) steps in `workflow.yaml`.
*   **Increased Defaults:** This changes the effective default workflow polling timeout from **30 minutes** (1800s) to **6 hours** (21600s), aligned with the default timeout variables defined in the stack configuration.
