### PR TITLE
fix(infra): resolve invalid count argument for postprocessing BQ connection IAM role

### DIFF
--- a/infra/dcp/modules/ingestion/postprocessing_job/main.tf
+++ b/infra/dcp/modules/ingestion/postprocessing_job/main.tf
@@ -99,7 +99,7 @@ resource "google_project_iam_member" "postprocessing_bq_job_user" {
 }
 
 resource "google_project_iam_member" "postprocessing_bq_connection_user" {
-  count   = var.enable_bigquery_postprocessing && var.bigquery_connection_id != "" ? 1 : 0
+  count   = var.enable_bigquery_postprocessing && var.enable_bigquery_connection ? 1 : 0
   project = var.project_id
   role    = "roles/bigquery.connectionUser"
   member  = "serviceAccount:${google_service_account.postprocessing_sa.email}"

--- a/infra/dcp/modules/ingestion/postprocessing_job/variables.tf
+++ b/infra/dcp/modules/ingestion/postprocessing_job/variables.tf
@@ -25,6 +25,11 @@ variable "bigquery_connection_id" { type = string }
 variable "use_spanner" { type = bool }
 variable "enable_bigquery_postprocessing" { type = bool }
 variable "enable_spanner_embeddings" { type = bool }
+variable "enable_bigquery_connection" {
+  type    = bool
+  default = false
+}
+
 
 variable "env_vars" {
   type = list(object({

--- a/infra/dcp/modules/ingestion/postprocessing_job/variables.tf
+++ b/infra/dcp/modules/ingestion/postprocessing_job/variables.tf
@@ -26,8 +26,9 @@ variable "use_spanner" { type = bool }
 variable "enable_bigquery_postprocessing" { type = bool }
 variable "enable_spanner_embeddings" { type = bool }
 variable "enable_bigquery_connection" {
-  type    = bool
-  default = false
+  description = "Enable BigQuery connection for post-processing. Requires Spanner module to be enabled with BigQuery connection support (spanner_config.enable = true and spanner_config.enable_bigquery_connection = true)."
+  type        = bool
+  default     = false
 }
 
 

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -163,6 +163,7 @@ module "ingestion_postprocessing_job" {
   use_spanner                    = var.spanner_config.enable
   enable_bigquery_postprocessing = var.ingestion_config.workflow_enable_bigquery_postprocessing
   enable_spanner_embeddings      = var.spanner_config.enable_embeddings_generation
+  enable_bigquery_connection     = var.spanner_config.enable && var.spanner_config.enable_bigquery_connection
   env_vars                       = local.cloud_run_shared_env_variables
 }
 


### PR DESCRIPTION
Fixes an "Invalid count argument" error during fresh Terraform deployments of the Data Commons Platform:

```
Error: Invalid count argument

  on .terraform/modules/stack/infra/dcp/modules/ingestion/postprocessing_job/main.tf line 102, in resource "google_project_iam_member" "postprocessing_bq_connection_user":
 102:   count   = var.enable_bigquery_postprocessing && var.bigquery_connection_id != "" ? 1 : 0

The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created.
```

### Cause
The BigQuery connection ID is a dynamically generated attribute from a resource created during the same `apply` phase, making it unknown at plan-time. Checking `var.bigquery_connection_id != ""` directly inside `count` causes planning to fail on fresh environments.

### Solution
Added a boolean toggle `enable_bigquery_connection` to control the IAM member's `count` instead of checking the dynamic connection ID.
