### PR TITLE
Rename "namespace" in deployment scripts to "instance_name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ uv run datacommons admin init
 
 The command will prompt for:
 - GCP project id
-- namespace
+- Instance name
 - Data Commons API key
 
 It then creates a new folder with `main.tf`, `terraform.tfvars`, and a deployment `README.md`.

--- a/experimental/terraform/modules/platform_service/main.tf
+++ b/experimental/terraform/modules/platform_service/main.tf
@@ -1,6 +1,6 @@
 locals {
-  name_prefix = var.namespace != "" ? "${var.namespace}-" : ""
-  display_name_prefix = var.namespace != "" ? "(${var.namespace}) " : ""
+  name_prefix = var.instance_name != "" ? "${var.instance_name}-" : ""
+  display_name_prefix = var.instance_name != "" ? "(${var.instance_name}) " : ""
 }
 
 resource "google_service_account" "runner" {

--- a/experimental/terraform/modules/platform_service/variables.tf
+++ b/experimental/terraform/modules/platform_service/variables.tf
@@ -1,4 +1,4 @@
-variable "namespace" {
+variable "instance_name" {
   type = string
 }
 

--- a/infra/dcp/README.md
+++ b/infra/dcp/README.md
@@ -41,7 +41,7 @@ cp terraform.tfvars.template terraform.tfvars
 
 Edit `terraform.tfvars` and fill in at least the following required variables:
 *   `project_id`: Your GCP Project ID.
-*   `namespace`: A unique identifier for resource naming (e.g., your name or team name).
+*   `instance_name`: A unique identifier for resource naming (e.g., your name or team name).
 
 ### 2. Run the Setup Script
 
@@ -103,17 +103,17 @@ Upon successful apply, Terraform displays key endpoints and resource names:
 After successful deployment with `deploy_ingestion_workflow = true`, you can run the automated ingestion pipeline.
 
 ### Step 1: Upload your Schema file
-Upload your custom graph nodes file (`.mcf`) to the provisioned ingestion bucket. By default, the bucket name format is: `<namespace>-ingestion-bucket-<project_id>`.
+Upload your custom graph nodes file (`.mcf`) to the provisioned ingestion bucket. By default, the bucket name format is: `<instance_name>-ingestion-bucket-<project_id>`.
 
 ```bash
-gcloud storage cp path/to/your/sample.mcf gs://<namespace>-ingestion-bucket-<project_id>/imports/sample.mcf
+gcloud storage cp path/to/your/sample.mcf gs://<instance_name>-ingestion-bucket-<project_id>/imports/sample.mcf
 ```
 
 ### Step 2: Trigger the Workflow Orchestrator
 Trigger the Cloud Workflow to start the Dataflow job that will read the file and insert it into Spanner.
 
 ```bash
-gcloud workflows run <namespace>-ingestion-orchestrator \
+gcloud workflows run <instance_name>-ingestion-orchestrator \
   --project=<project_id> \
   --location=<region> \
   --data='{
@@ -121,8 +121,8 @@ gcloud workflows run <namespace>-ingestion-orchestrator \
     "region": "<region>",
     "spannerInstanceId": "<spanner-instance-id>",
     "spannerDatabaseId": "<spanner-database-id>",
-    "importList": "[{\"importName\": \"SampleTestCase\", \"graphPath\": \"gs://<namespace>-ingestion-bucket-<project_id>/imports/sample.mcf\"}]",
-    "tempLocation": "gs://<namespace>-ingestion-bucket-<project_id>/temp"
+    "importList": "[{\"importName\": \"SampleTestCase\", \"graphPath\": \"gs://<instance_name>-ingestion-bucket-<project_id>/imports/sample.mcf\"}]",
+    "tempLocation": "gs://<instance_name>-ingestion-bucket-<project_id>/temp"
   }'
 ```
 

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -65,7 +65,7 @@ locals {
   global_config = {
     project_id                    = var.project_id
     region                        = var.region
-    namespace                     = var.namespace
+    instance_name                 = var.instance_name
     stateful_deletion_protection  = var.stateful_deletion_protection
     stateless_deletion_protection = var.stateless_deletion_protection
   }

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -65,7 +65,7 @@ locals {
   global_config = {
     project_id                    = var.project_id
     region                        = var.region
-    instance_name                 = var.instance_name
+    instance_name                 = var.instance_name != "" ? var.instance_name : var.namespace
     stateful_deletion_protection  = var.stateful_deletion_protection
     stateless_deletion_protection = var.stateless_deletion_protection
   }

--- a/infra/dcp/modules/auth/main.tf
+++ b/infra/dcp/modules/auth/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name_prefix               = var.namespace != "" ? "${var.namespace}-" : ""
+  name_prefix               = var.instance_name != "" ? "${var.instance_name}-" : ""
   google_maps_api_key_value = var.google_maps_api_key != null ? var.google_maps_api_key : try(google_apikeys_key.maps_api_key[0].key_string, "")
 }
 
@@ -24,7 +24,7 @@ resource "google_apikeys_key" "maps_api_key" {
   count = var.google_maps_api_key == null && var.create_google_maps_key ? 1 : 0
 
   name         = "${local.name_prefix}dc-google-maps-key-${random_id.api_key_suffix.hex}"
-  display_name = "Maps API Key for ${var.namespace != "" ? var.namespace : "Data Commons"}"
+  display_name = "Maps API Key for ${var.instance_name != "" ? var.instance_name : "Data Commons"}"
   project      = var.project_id
 
   restrictions {

--- a/infra/dcp/modules/auth/variables.tf
+++ b/infra/dcp/modules/auth/variables.tf
@@ -2,7 +2,7 @@ variable "project_id" {
   type = string
 }
 
-variable "namespace" {
+variable "instance_name" {
   type = string
 }
 

--- a/infra/dcp/modules/datacommons_services/main.tf
+++ b/infra/dcp/modules/datacommons_services/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name_prefix = var.namespace != "" ? "${var.namespace}-" : ""
+  name_prefix = var.instance_name != "" ? "${var.instance_name}-" : ""
 }
 
 resource "google_service_account" "serving_sa" {

--- a/infra/dcp/modules/datacommons_services/variables.tf
+++ b/infra/dcp/modules/datacommons_services/variables.tf
@@ -5,7 +5,7 @@ variable "project_id" {
   type = string
 }
 
-variable "namespace" {
+variable "instance_name" {
   type = string
 }
 

--- a/infra/dcp/modules/ingestion/dataflow/main.tf
+++ b/infra/dcp/modules/ingestion/dataflow/main.tf
@@ -1,6 +1,6 @@
 locals {
-  name_prefix         = var.namespace != "" ? "${var.namespace}-" : ""
-  display_name_prefix = var.namespace != "" ? "(${var.namespace}) " : ""
+  name_prefix         = var.instance_name != "" ? "${var.instance_name}-" : ""
+  display_name_prefix = var.instance_name != "" ? "(${var.instance_name}) " : ""
 }
 
 resource "google_service_account" "dataflow_sa" {

--- a/infra/dcp/modules/ingestion/dataflow/variables.tf
+++ b/infra/dcp/modules/ingestion/dataflow/variables.tf
@@ -6,7 +6,7 @@ variable "project_id" {
   type = string
 }
 
-variable "namespace" {
+variable "instance_name" {
   type = string
 }
 

--- a/infra/dcp/modules/ingestion/helper_service/main.tf
+++ b/infra/dcp/modules/ingestion/helper_service/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name_prefix = var.namespace != "" ? "${var.namespace}-" : ""
+  name_prefix = var.instance_name != "" ? "${var.instance_name}-" : ""
 }
 
 resource "google_service_account" "helper_sa" {

--- a/infra/dcp/modules/ingestion/helper_service/variables.tf
+++ b/infra/dcp/modules/ingestion/helper_service/variables.tf
@@ -6,7 +6,7 @@ variable "project_id" {
   type = string
 }
 
-variable "namespace" {
+variable "instance_name" {
   type = string
 }
 

--- a/infra/dcp/modules/ingestion/postprocessing_job/main.tf
+++ b/infra/dcp/modules/ingestion/postprocessing_job/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name_prefix = var.namespace != "" ? "${var.namespace}-" : ""
+  name_prefix = var.instance_name != "" ? "${var.instance_name}-" : ""
 }
 
 resource "google_service_account" "postprocessing_sa" {

--- a/infra/dcp/modules/ingestion/postprocessing_job/variables.tf
+++ b/infra/dcp/modules/ingestion/postprocessing_job/variables.tf
@@ -1,5 +1,5 @@
 variable "project_id" { type = string }
-variable "namespace" { type = string }
+variable "instance_name" { type = string }
 variable "region" { type = string }
 variable "stateless_deletion_protection" {
   type        = bool

--- a/infra/dcp/modules/ingestion/preprocessing_job/main.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name_prefix = var.namespace != "" ? "${var.namespace}-" : ""
+  name_prefix = var.instance_name != "" ? "${var.instance_name}-" : ""
 }
 
 resource "google_service_account" "preprocessing_sa" {

--- a/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
+++ b/infra/dcp/modules/ingestion/preprocessing_job/variables.tf
@@ -1,5 +1,5 @@
 variable "project_id" { type = string }
-variable "namespace" { type = string }
+variable "instance_name" { type = string }
 variable "region" { type = string }
 variable "stateless_deletion_protection" {
   type        = bool

--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -1,7 +1,7 @@
 locals {
-  name_prefix               = var.namespace != "" ? "${var.namespace}-" : ""
+  name_prefix               = var.instance_name != "" ? "${var.instance_name}-" : ""
   should_run_postprocessing = var.enable_bigquery_postprocessing || var.enable_embeddings_generation
-  clean_namespace_prefix    = var.namespace != "" ? "${replace(lower(var.namespace), "_", "-")}-" : ""
+  clean_instance_name_prefix = var.instance_name != "" ? "${replace(lower(var.instance_name), "_", "-")}-" : ""
 }
 
 resource "google_service_account" "workflow_sa" {
@@ -30,7 +30,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
     dataflow_ip_configuration      = var.dataflow_ip_configuration
     dataflow_subnetwork            = var.dataflow_subnetwork
     embeddings_timeout             = var.embeddings_timeout
-    clean_namespace_prefix         = local.clean_namespace_prefix
+    clean_instance_name_prefix     = local.clean_instance_name_prefix
     enable_redis_cache_clearing    = var.enable_redis_cache_clearing
     preprocessing_job_name         = var.preprocessing_job_name
     postprocessing_job_name        = var.postprocessing_job_name

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -2,7 +2,7 @@ variable "deploy" {
   type = bool
 }
 
-variable "namespace" {
+variable "instance_name" {
   type = string
 }
 

--- a/infra/dcp/modules/ingestion/workflow/workflow.yaml
+++ b/infra/dcp/modules/ingestion/workflow/workflow.yaml
@@ -96,7 +96,7 @@ main:
           - import_name_len: '$${len(combined_import_name)}'
           - substring_end: '$${if(import_name_len < 35, import_name_len, 35)}'
           - sanitized_short_import: '$${text.substring(combined_import_name, 0, substring_end)}'
-          - dataflow_job_name: '$${"${clean_namespace_prefix}" + sanitized_short_import + "-" + string(int(sys.now()))}'
+          - dataflow_job_name: '$${"${clean_instance_name_prefix}" + sanitized_short_import + "-" + string(int(sys.now()))}'
     
     - run_preprocessing:
         call: launch_and_poll_preprocessing_job

--- a/infra/dcp/modules/redis/main.tf
+++ b/infra/dcp/modules/redis/main.tf
@@ -1,10 +1,10 @@
 locals {
-  name_prefix         = var.namespace != "" ? "${var.namespace}-" : ""
-  display_name_prefix = var.namespace != "" ? "(${var.namespace}) " : ""
+  name_prefix         = var.instance_name != "" ? "${var.instance_name}-" : ""
+  display_name_prefix = var.instance_name != "" ? "(${var.instance_name}) " : ""
 }
 
 resource "google_redis_instance" "redis_instance" {
-  name                    = var.instance_name != "" ? "${local.name_prefix}${var.instance_name}" : "${local.name_prefix}dc-redis-instance"
+  name                    = var.redis_instance_name != "" ? "${local.name_prefix}${var.redis_instance_name}" : "${local.name_prefix}dc-redis-instance"
   memory_size_gb          = var.memory_size_gb
   tier                    = var.tier
   region                  = var.region

--- a/infra/dcp/modules/redis/variables.tf
+++ b/infra/dcp/modules/redis/variables.tf
@@ -1,4 +1,4 @@
-variable "namespace" {
+variable "instance_name" {
   type = string
 }
 
@@ -6,7 +6,7 @@ variable "region" {
   type = string
 }
 
-variable "instance_name" {
+variable "redis_instance_name" {
   type    = string
   default = ""
 }

--- a/infra/dcp/modules/spanner/main.tf
+++ b/infra/dcp/modules/spanner/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name_prefix           = var.namespace != "" ? "${var.namespace}-" : ""
+  name_prefix           = var.instance_name != "" ? "${var.instance_name}-" : ""
   effective_instance_id = var.create_instance ? (var.instance_id != "" ? "${local.name_prefix}${var.instance_id}" : "${local.name_prefix}dc-instance") : var.instance_id
   effective_database_id = var.create_database ? (var.database_id != "" ? "${local.name_prefix}${var.database_id}" : "${local.name_prefix}dc-db") : var.database_id
 }

--- a/infra/dcp/modules/spanner/variables.tf
+++ b/infra/dcp/modules/spanner/variables.tf
@@ -3,7 +3,7 @@ variable "project_id" {
   description = "GCP Project ID"
 }
 
-variable "namespace" {
+variable "instance_name" {
   type = string
 }
 

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -80,7 +80,7 @@ module "spanner" {
   count  = var.spanner_config.enable ? 1 : 0
 
   project_id                         = var.global.project_id
-  namespace                          = var.global.namespace
+  instance_name                      = var.global.instance_name
   region                             = var.global.region
   create_instance                    = var.spanner_config.create_instance
   create_database                    = var.spanner_config.create_db
@@ -107,7 +107,7 @@ module "storage" {
 
   # Shared vars
   project_id = var.global.project_id
-  namespace  = var.global.namespace
+  instance_name = var.global.instance_name
 }
 
 module "ingestion_preprocessing_job" {
@@ -115,7 +115,7 @@ module "ingestion_preprocessing_job" {
   count  = var.ingestion_config.enable_ingestion ? 1 : 0
 
   project_id                    = var.global.project_id
-  namespace                     = var.global.namespace
+  instance_name                 = var.global.instance_name
   region                        = var.global.region
   stateless_deletion_protection = var.global.stateless_deletion_protection
   image                         = var.ingestion_config.preprocessing_job_image
@@ -149,7 +149,7 @@ module "ingestion_postprocessing_job" {
   count  = var.ingestion_config.enable_ingestion ? 1 : 0
 
   project_id                     = var.global.project_id
-  namespace                      = var.global.namespace
+  instance_name                  = var.global.instance_name
   region                         = var.global.region
   stateless_deletion_protection  = var.global.stateless_deletion_protection
   image                          = var.ingestion_config.postprocessing_job_image
@@ -172,7 +172,7 @@ module "ingestion_dataflow" {
 
   deploy                = var.ingestion_config.enable_ingestion
   project_id            = var.global.project_id
-  namespace             = var.global.namespace
+  instance_name         = var.global.instance_name
   ingestion_bucket_name = module.storage.artifacts_bucket_name
   use_spanner           = var.spanner_config.enable
 }
@@ -182,7 +182,7 @@ module "ingestion_helper_service" {
 
   deploy                        = var.ingestion_config.enable_ingestion
   project_id                    = var.global.project_id
-  namespace                     = var.global.namespace
+  instance_name                 = var.global.instance_name
   region                        = var.global.region
   stateless_deletion_protection = var.global.stateless_deletion_protection
   # Use index [0] because module.spanner is conditional. Fallback to empty string if disabled.
@@ -208,7 +208,7 @@ module "ingestion_workflow" {
   source = "../ingestion/workflow"
 
   deploy                         = var.ingestion_config.enable_ingestion
-  namespace                      = var.global.namespace
+  instance_name                  = var.global.instance_name
   region                         = var.global.region
   stateless_deletion_protection  = var.global.stateless_deletion_protection
   project_id                     = var.global.project_id
@@ -217,7 +217,7 @@ module "ingestion_workflow" {
   dataflow_service_account_email = module.ingestion_dataflow.service_account_email
   enable_bigquery_postprocessing = var.ingestion_config.workflow_enable_bigquery_postprocessing
   enable_embeddings_generation   = var.spanner_config.enable_embeddings_generation
-  ingestion_helper_service_name  = "${var.global.namespace != "" ? "${var.global.namespace}-" : ""}dc-ingestion-helper"
+  ingestion_helper_service_name  = "${var.global.instance_name != "" ? "${var.global.instance_name}-" : ""}dc-ingestion-helper"
   enable_redis_cache_clearing    = var.redis_config.enable
   ingestion_artifacts_path       = "${var.ingestion_config.ingestion_artifacts_path}/metadata"
   dataflow_ip_configuration      = var.ingestion_config.dataflow_ip_configuration
@@ -233,9 +233,9 @@ module "redis" {
   source = "../redis"
   count  = var.redis_config.enable ? 1 : 0
 
-  namespace               = var.global.namespace
+  instance_name           = var.global.instance_name
   region                  = var.global.region
-  instance_name           = var.redis_config.instance_name
+  redis_instance_name     = var.redis_config.instance_name
   memory_size_gb          = var.redis_config.memory_size_gb
   tier                    = var.redis_config.tier
   location_id             = var.redis_config.location_id
@@ -250,7 +250,7 @@ module "auth" {
   source = "../auth"
 
   project_id             = var.global.project_id
-  namespace              = var.global.namespace
+  instance_name          = var.global.instance_name
   dc_api_key             = var.auth_config.google_datacommons_api_key
   google_maps_api_key    = var.auth_config.google_maps_api_key
   create_google_maps_key = var.auth_config.create_google_maps_key
@@ -261,7 +261,7 @@ module "datacommons_services" {
   count  = var.datacommons_services_config.enable ? 1 : 0
 
   project_id                    = var.global.project_id
-  namespace                     = var.global.namespace
+  instance_name                 = var.global.instance_name
   region                        = var.global.region
   stateless_deletion_protection = var.global.stateless_deletion_protection
   image                         = var.datacommons_services_config.image

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -2,7 +2,7 @@ variable "global" {
   type = object({
     project_id                    = string
     region                        = string
-    namespace                     = string
+    instance_name                 = string
     stateful_deletion_protection  = bool
     stateless_deletion_protection = bool
   })

--- a/infra/dcp/modules/storage/main.tf
+++ b/infra/dcp/modules/storage/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name_prefix           = var.namespace != "" ? "${var.namespace}-" : ""
+  name_prefix           = var.instance_name != "" ? "${var.instance_name}-" : ""
   artifacts_bucket_name = var.artifacts_bucket_name != "" ? var.artifacts_bucket_name : "${local.name_prefix}dc-artifacts-${var.project_id}"
 }
 

--- a/infra/dcp/modules/storage/variables.tf
+++ b/infra/dcp/modules/storage/variables.tf
@@ -2,7 +2,7 @@ variable "project_id" {
   type = string
 }
 
-variable "namespace" {
+variable "instance_name" {
   type = string
 }
 

--- a/infra/dcp/terraform.tfvars.template
+++ b/infra/dcp/terraform.tfvars.template
@@ -6,9 +6,9 @@
 # =============================================================================
 # Global Configuration
 # =============================================================================
-project_id = "$$PROJECT_ID$$"
+project_id    = "$$PROJECT_ID$$"
 instance_name = "$$INSTANCE_NAME$$"
-region = "us-central1"
+region        = "us-central1"
 
 # Deletion protection for stateful resources holding persistent data 
 # (Spanner and Cloud Storage).

--- a/infra/dcp/terraform.tfvars.template
+++ b/infra/dcp/terraform.tfvars.template
@@ -7,8 +7,8 @@
 # Global Configuration
 # =============================================================================
 project_id = "$$PROJECT_ID$$"
-namespace  = "$$NAMESPACE$$"
-region     = "us-central1"
+instance_name = "$$INSTANCE_NAME$$"
+region = "us-central1"
 
 # Deletion protection for stateful resources holding persistent data 
 # (Spanner and Cloud Storage).

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -82,7 +82,7 @@ variable "storage_create_artifacts_bucket" {
 }
 
 variable "storage_artifacts_bucket_name" {
-  description = "The name of the unified GCS bucket for artifacts (serving and ingestion). If not provided, a name will be automatically generated following the pattern [instance-name-]dc-artifacts-[project_id]"
+  description = "The name of the unified GCS bucket for artifacts (serving and ingestion). If not provided, a name will be automatically generated following the pattern [instance_name-]dc-artifacts-[project_id]"
   type        = string
   default     = ""
 }
@@ -98,7 +98,7 @@ variable "enable_redis" {
 }
 
 variable "redis_instance_name" {
-  description = "The name of the Redis instance. If not provided, a name will be automatically generated following the pattern [instance-name-]dc-redis-instance"
+  description = "The name of the Redis instance. If not provided, a name will be automatically generated following the pattern [instance_name-]dc-redis-instance"
   type        = string
   default     = ""
 }
@@ -168,13 +168,13 @@ variable "spanner_create_database" {
 }
 
 variable "spanner_instance_id" {
-  description = "The ID of the Spanner instance. If not provided, a name will be automatically generated following the pattern [instance-name-]dc-instance"
+  description = "The ID of the Spanner instance. If not provided, a name will be automatically generated following the pattern [instance_name-]dc-instance"
   type        = string
   default     = ""
 }
 
 variable "spanner_database_id" {
-  description = "The ID of the Spanner database. If not provided, a name will be automatically generated following the pattern [instance-name-]dc-db"
+  description = "The ID of the Spanner database. If not provided, a name will be automatically generated following the pattern [instance_name-]dc-db"
   type        = string
   default     = ""
 }

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -14,7 +14,7 @@ variable "region" {
 }
 
 variable "instance_name" {
-  description = "A unique identifier used to name resources in this deployment.  This prevents naming conflicts when deploying multiple isolated environments (like dev, staging, or feature branches) within the same GCP project."
+  description = "A unique identifier used as a prefix for resource naming. This prevents naming conflicts when deploying multiple isolated environments (like dev, staging, or feature branches) within the same GCP project."
   type        = string
   default     = ""
 }

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -13,8 +13,8 @@ variable "region" {
   default     = "us-central1"
 }
 
-variable "namespace" {
-  description = "A unique identifier used as a prefix for resource naming. This prevents naming conflicts when deploying multiple isolated environments (like dev, staging, or feature branches) within the same GCP project."
+variable "instance_name" {
+  description = "A unique identifier used to name resources in this deployment.  This prevents naming conflicts when deploying multiple isolated environments (like dev, staging, or feature branches) within the same GCP project."
   type        = string
   default     = ""
 }
@@ -82,7 +82,7 @@ variable "storage_create_artifacts_bucket" {
 }
 
 variable "storage_artifacts_bucket_name" {
-  description = "The name of the unified GCS bucket for artifacts (serving and ingestion). If not provided, a name will be automatically generated following the pattern [namespace-]dc-artifacts-[project_id]"
+  description = "The name of the unified GCS bucket for artifacts (serving and ingestion). If not provided, a name will be automatically generated following the pattern [instance-name-]dc-artifacts-[project_id]"
   type        = string
   default     = ""
 }
@@ -98,7 +98,7 @@ variable "enable_redis" {
 }
 
 variable "redis_instance_name" {
-  description = "The name of the Redis instance. If not provided, a name will be automatically generated following the pattern [namespace-]dc-redis-instance"
+  description = "The name of the Redis instance. If not provided, a name will be automatically generated following the pattern [instance-name-]dc-redis-instance"
   type        = string
   default     = ""
 }
@@ -168,13 +168,13 @@ variable "spanner_create_database" {
 }
 
 variable "spanner_instance_id" {
-  description = "The ID of the Spanner instance. If not provided, a name will be automatically generated following the pattern [namespace-]dc-instance"
+  description = "The ID of the Spanner instance. If not provided, a name will be automatically generated following the pattern [instance-name-]dc-instance"
   type        = string
   default     = ""
 }
 
 variable "spanner_database_id" {
-  description = "The ID of the Spanner database. If not provided, a name will be automatically generated following the pattern [namespace-]dc-db"
+  description = "The ID of the Spanner database. If not provided, a name will be automatically generated following the pattern [instance-name-]dc-db"
   type        = string
   default     = ""
 }

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -19,6 +19,12 @@ variable "instance_name" {
   default     = ""
 }
 
+variable "namespace" {
+  description = "Deprecated alias for instance_name. Used to maintain backward-compatibility with existing Terraform configurations."
+  type        = string
+  default     = ""
+}
+
 variable "stateful_deletion_protection" {
   description = "Enable deletion protection for stateful resources (Spanner, GCS) to prevent data loss."
   type        = bool

--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -364,7 +364,9 @@ def _setup_dcp_config_dir(
         # Modify tfvars_example with actual values
         tfvars_content = tfvars_example
         tfvars_content = tfvars_content.replace('"$$PROJECT_ID$$"', f'"{project_id}"')
-        tfvars_content = tfvars_content.replace('"$$INSTANCE_NAME$$"', f'"{instance_name}"')
+        tfvars_content = tfvars_content.replace(
+            '"$$INSTANCE_NAME$$"', f'"{instance_name}"'
+        )
         if api_key:
             tfvars_content = tfvars_content.replace('"$$DC_API_KEY$$"', f'"{api_key}"')
 
@@ -401,7 +403,9 @@ def _setup_dcp_config_dir(
     help="Google Cloud Platform project ID used for all resources related to your Data Commons instance.",
 )
 @click.option(
-    "--instance-name", default="", help="Instance name that serves as prefix for provisioned resources."
+    "--instance-name",
+    default="",
+    help="Instance name that serves as prefix for provisioned resources.",
 )
 @click.option("--dc-api-key", default="", help="Data Commons API key.")
 @click.option(

--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -404,8 +404,9 @@ def _setup_dcp_config_dir(
 )
 @click.option(
     "--instance-name",
+    "--namespace",
     default="",
-    help="Instance name that serves as prefix for provisioned resources.",
+    help="Instance name that serves as prefix for provisioned resources. (Deprecated alias: --namespace)",
 )
 @click.option("--dc-api-key", default="", help="Data Commons API key.")
 @click.option(

--- a/packages/datacommons-admin/datacommons_admin/admin_cli.py
+++ b/packages/datacommons-admin/datacommons_admin/admin_cli.py
@@ -35,14 +35,14 @@ GITHUB_RAW_BASE_URL = "https://raw.githubusercontent.com/datacommonsorg/datacomm
 GITHUB_REPO_URL = "https://github.com/datacommonsorg/datacommons.git"
 
 
-def _get_default_bucket_name(namespace: str, project_id: str) -> str:
+def _get_default_bucket_name(instance_name: str, project_id: str) -> str:
     """Returns the default Google Cloud Storage bucket name for Terraform state."""
-    return f"tf-state-{namespace}-{project_id}"
+    return f"tf-state-{instance_name}-{project_id}"
 
 
-def _get_default_state_prefix(namespace: str) -> str:
+def _get_default_state_prefix(instance_name: str) -> str:
     """Returns the default Google Cloud Storage object prefix for Terraform state."""
-    return f"terraform/state/{namespace}"
+    return f"terraform/state/{instance_name}"
 
 
 def _log_resolved_value(label: str, value: str, is_default: bool, indent: int = 2):
@@ -151,7 +151,7 @@ def _ensure_bucket_ready(
 
 def _configure_remote_state(
     project_id: str,
-    namespace: str,
+    instance_name: str,
     bucket_name: str = "",
     location: str = DEFAULT_BUCKET_LOCATION,
 ) -> str:
@@ -166,7 +166,7 @@ def _configure_remote_state(
 
     is_default = False
     if not bucket_name:
-        bucket_name = _get_default_bucket_name(namespace, project_id)
+        bucket_name = _get_default_bucket_name(instance_name, project_id)
         is_default = True
 
     click.echo(
@@ -229,30 +229,30 @@ def admin() -> None:
     """Manage a Data Commons Platform instance in Google Cloud"""
 
 
-def _validate_namespace(ns: str) -> Tuple[bool, str]:
-    if not ns:
-        return False, "Namespace must not be empty."
-    if len(ns) > 16:
+def _validate_instance_name(instance_name: str) -> Tuple[bool, str]:
+    if not instance_name:
+        return False, "Instance name must not be empty."
+    if len(instance_name) > 16:
         return (
             False,
-            f"Namespace must be 16 characters or less (currently {len(ns)} characters).",
+            f"Instance name must be 16 characters or less (currently {len(instance_name)} characters).",
         )
-    if not re.match(r"^[a-z]([-a-z0-9]*[a-z0-9])?$", ns):
+    if not re.match(r"^[a-z]([-a-z0-9]*[a-z0-9])?$", instance_name):
         return (
             False,
-            "Namespace must start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase alphanumeric characters and dashes.",
+            "Instance name must start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase alphanumeric characters and dashes.",
         )
     return True, ""
 
 
 def _resolve_project_config(
-    project_id: str, namespace: str, force: bool
+    project_id: str, instance_name: str, force: bool
 ) -> Tuple[str, str, Path]:
-    """Resolves project ID and namespace, and determines target directory."""
+    """Resolves project ID and instance name, and determines target directory."""
     if project_id:
         _log_resolved_value("Project ID", project_id, is_default=False)
-    if namespace:
-        _log_resolved_value("Namespace", namespace, is_default=False)
+    if instance_name:
+        _log_resolved_value("Instance Name", instance_name, is_default=False)
 
     resolved_project_id = project_id.strip()
     if not resolved_project_id:
@@ -262,34 +262,34 @@ def _resolve_project_config(
     if not resolved_project_id:
         raise click.ClickException("GCP project ID must not be empty.")
 
-    resolved_namespace = namespace.strip()
-    if resolved_namespace:
-        is_valid, err_msg = _validate_namespace(resolved_namespace)
+    resolved_instance_name = instance_name.strip()
+    if resolved_instance_name:
+        is_valid, err_msg = _validate_instance_name(resolved_instance_name)
         if not is_valid:
             raise click.ClickException(err_msg)
 
     while True:
-        if not resolved_namespace:
-            resolved_namespace = _prompt("Namespace", type=str).strip()
-            is_valid, err_msg = _validate_namespace(resolved_namespace)
+        if not resolved_instance_name:
+            resolved_instance_name = _prompt("Instance Name", type=str).strip()
+            is_valid, err_msg = _validate_instance_name(resolved_instance_name)
             if not is_valid:
                 click.secho(f"Error: {err_msg}", fg="red")
-                resolved_namespace = ""
+                resolved_instance_name = ""
                 continue
 
-        target_dir = Path.cwd() / resolved_namespace
+        target_dir = Path.cwd() / resolved_instance_name
         if target_dir.exists() and not force:
             click.secho(
-                f"Error: Folder '{resolved_namespace}' already exists locally. "
-                "Please specify a different namespace, or use --force to overwrite.",
+                f"Error: Folder '{resolved_instance_name}' already exists locally. "
+                "Please specify a different instance name, or use --force to overwrite.",
                 fg="yellow",
             )
-            resolved_namespace = ""
+            resolved_instance_name = ""
             continue
 
         break
 
-    return resolved_project_id, resolved_namespace, target_dir
+    return resolved_project_id, resolved_instance_name, target_dir
 
 
 def _check_existing_files(target_dir: Path, use_remote_state: bool, force: bool):
@@ -315,7 +315,7 @@ def _check_existing_files(target_dir: Path, use_remote_state: bool, force: bool)
 def _setup_dcp_config_dir(
     target_dir: Path,
     project_id: str,
-    namespace: str,
+    instance_name: str,
     bucket_name: str,
     tf_state_prefix: str,
     dc_api_key: str,
@@ -364,7 +364,7 @@ def _setup_dcp_config_dir(
         # Modify tfvars_example with actual values
         tfvars_content = tfvars_example
         tfvars_content = tfvars_content.replace('"$$PROJECT_ID$$"', f'"{project_id}"')
-        tfvars_content = tfvars_content.replace('"$$NAMESPACE$$"', f'"{namespace}"')
+        tfvars_content = tfvars_content.replace('"$$INSTANCE_NAME$$"', f'"{instance_name}"')
         if api_key:
             tfvars_content = tfvars_content.replace('"$$DC_API_KEY$$"', f'"{api_key}"')
 
@@ -401,7 +401,7 @@ def _setup_dcp_config_dir(
     help="Google Cloud Platform project ID used for all resources related to your Data Commons instance.",
 )
 @click.option(
-    "--namespace", default="", help="Namespace prefix for provisioned resources."
+    "--instance-name", default="", help="Instance name that serves as prefix for provisioned resources."
 )
 @click.option("--dc-api-key", default="", help="Data Commons API key.")
 @click.option(
@@ -432,11 +432,11 @@ def _setup_dcp_config_dir(
 @click.option(
     "--tf-state-prefix",
     default="",
-    help="Google Cloud Storage object prefix for Terraform state file (default: terraform/state/{namespace}).",
+    help="Google Cloud Storage object prefix for Terraform state file (default: terraform/state/{instance_name}).",
 )
 def init(
     project_id: str,
-    namespace: str,
+    instance_name: str,
     dc_api_key: str,
     tf_git_ref: str,
     force: bool,
@@ -451,8 +451,8 @@ def init(
     # 1. Project Configs
     click.secho("\n[Project configuration]", fg="cyan", bold=True)
     click.secho("Configuring project settings...", fg="bright_black")
-    resolved_project_id, resolved_namespace, target_dir = _resolve_project_config(
-        project_id, namespace, force
+    resolved_project_id, resolved_instance_name, target_dir = _resolve_project_config(
+        project_id, instance_name, force
     )
 
     # 2. Terraform Setup
@@ -467,7 +467,7 @@ def init(
     resolved_bucket_name = (
         _configure_remote_state(
             resolved_project_id,
-            resolved_namespace,
+            resolved_instance_name,
             tf_state_bucket,
             tf_state_bucket_location,
         )
@@ -476,7 +476,7 @@ def init(
     )
 
     resolved_tf_state_prefix = tf_state_prefix.strip() or _get_default_state_prefix(
-        resolved_namespace
+        resolved_instance_name
     )
 
     # 3. DCP config dir setup
@@ -485,7 +485,7 @@ def init(
     _setup_dcp_config_dir(
         target_dir,
         resolved_project_id,
-        resolved_namespace,
+        resolved_instance_name,
         resolved_bucket_name,
         resolved_tf_state_prefix,
         dc_api_key,
@@ -494,7 +494,7 @@ def init(
     )
 
     click.secho(
-        f"Customize variables in {resolved_namespace}/terraform.tfvars as needed.",
+        f"Customize variables in {resolved_instance_name}/terraform.tfvars as needed.",
         fg="green",
     )
     click.secho(

--- a/packages/datacommons-admin/datacommons_admin/infra_templates.py
+++ b/packages/datacommons-admin/datacommons_admin/infra_templates.py
@@ -36,7 +36,7 @@ This setup deploys core Data Commons Platform infrastructure on GCP using the `i
 
 ## Configure Variables
 
-Set environment-specific values in `terraform.tfvars` (for example `project_id`, `namespace`, and `dc_api_key`), and update module arguments in `main.tf` if you want to enable or tune additional features.
+Set environment-specific values in `terraform.tfvars` (for example `project_id`, `instance_name`, and `dc_api_key`), and update module arguments in `main.tf` if you want to enable or tune additional features.
 
 ## Learn More About Variables
 

--- a/packages/datacommons-admin/datacommons_admin/tf_utils.py
+++ b/packages/datacommons-admin/datacommons_admin/tf_utils.py
@@ -71,7 +71,7 @@ def get_terraform_output(key: str) -> str:
         if not has_tf_files:
             raise click.ClickException(
                 f"No Terraform outputs found in '{cwd}'.\n"
-                "Please navigate to your initialized DCP Terraform directory (e.g., 'cd my-namespace') and ensure 'terraform apply' has been run."
+                "Please navigate to your initialized DCP Terraform directory (e.g., 'cd my-instance-name') and ensure 'terraform apply' has been run."
             )
         else:
             raise click.ClickException(

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -34,7 +34,7 @@ def test_init_success_with_options(
         'variable "test" {}',
         'module "stack" {\n  source = "./modules/stack"\n}',
         'output "test" {}',
-        'project_id = "$$PROJECT_ID$$"\nnamespace  = "$$NAMESPACE$$"\n# dc_api_key = "$$DC_API_KEY$$"',
+        'project_id = "$$PROJECT_ID$$"\ninstance_name  = "$$INSTANCE_NAME$$"\n# dc_api_key = "$$DC_API_KEY$$"',
     )
     with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(
@@ -43,8 +43,8 @@ def test_init_success_with_options(
                 "init",
                 "--project-id",
                 "test-project",
-                "--namespace",
-                "test-ns",
+                "--instance-name",
+                "test-instance-name",
                 "--dc-api-key",
                 "test-key",
                 "--no-tf-remote-state",
@@ -62,7 +62,7 @@ def test_init_success_with_options(
 
         tfvars_content = (target_dir / "terraform.tfvars").read_text()
         assert 'project_id = "test-project"' in tfvars_content
-        assert 'namespace  = "test-ns"' in tfvars_content
+        assert 'instance_name  = "test-instance-name"' in tfvars_content
         assert 'dc_api_key = "test-key"' in tfvars_content
 
 
@@ -74,21 +74,21 @@ def test_init_success_with_prompts(
         'variable "test" {}',
         'module "stack" {\n  source = "./modules/stack"\n}',
         'output "test" {}',
-        'project_id = "$$PROJECT_ID$$"\nnamespace  = "$$NAMESPACE$$"\n# dc_api_key = "$$DC_API_KEY$$"',
+        'project_id = "$$PROJECT_ID$$"\ninstance_name  = "$$INSTANCE_NAME$$"\n# dc_api_key = "$$DC_API_KEY$$"',
     )
     with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(
             admin,
             ["init", "--no-tf-remote-state"],
-            input="prompt-project\nprompt-ns\nprompt-key\n",
+            input="prompt-project\nprompt-instance-name\nprompt-key\n",
         )
         assert result.exit_code == 0
-        target_dir = Path.cwd() / "prompt-ns"
+        target_dir = Path.cwd() / "prompt-instance-name"
         assert target_dir.exists()
 
         tfvars_content = (target_dir / "terraform.tfvars").read_text()
         assert 'project_id = "prompt-project"' in tfvars_content
-        assert 'namespace  = "prompt-ns"' in tfvars_content
+        assert 'instance_name  = "prompt-instance-name"' in tfvars_content
 
 
 @patch("datacommons_admin.admin_cli._get_github_templates")
@@ -99,10 +99,10 @@ def test_init_existing_folder_force(
         'variable "test" {}',
         'module "stack" {\n  source = "./modules/stack"\n}',
         'output "test" {}',
-        'project_id = "$$PROJECT_ID$$"\nnamespace  = "$$NAMESPACE$$"\n# dc_api_key = "$$DC_API_KEY$$"',
+        'project_id = "$$PROJECT_ID$$"\ninstance_name  = "$$INSTANCE_NAME$$"\n# dc_api_key = "$$DC_API_KEY$$"',
     )
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        existing_dir = Path.cwd() / "existing-ns"
+        existing_dir = Path.cwd() / "existing-instance-name"
         existing_dir.mkdir()
         (existing_dir / "main.tf").write_text("old content")
 
@@ -112,8 +112,8 @@ def test_init_existing_folder_force(
                 "init",
                 "--project-id",
                 "test-project",
-                "--namespace",
-                "existing-ns",
+                "--instance-name",
+                "existing-instance-name",
                 "--force",
                 "--no-tf-remote-state",
             ],
@@ -136,7 +136,7 @@ def test_init_remote_state(
         'variable "test" {}',
         'module "stack" {\n  source = "./modules/stack"\n}',
         'output "test" {}',
-        'project_id = "$$PROJECT_ID$$"\nnamespace  = "$$NAMESPACE$$"\n# dc_api_key = "$$DC_API_KEY$$"',
+        'project_id = "$$PROJECT_ID$$"\ninstance_name  = "$$INSTANCE_NAME$$"\n# dc_api_key = "$$DC_API_KEY$$"',
     )
     mock_configure.return_value = "mock-bucket-name"
 
@@ -147,16 +147,18 @@ def test_init_remote_state(
                 "init",
                 "--project-id",
                 "remote-project",
-                "--namespace",
-                "remote-ns",
+                "--instance-name",
+                "remote-instance-name",
                 "--dc-api-key",
                 "remote-key",
             ],
         )
         assert result.exit_code == 0
-        mock_configure.assert_called_once_with("remote-project", "remote-ns", "", "US")
+        mock_configure.assert_called_once_with(
+            "remote-project", "remote-instance-name", "", "US"
+        )
 
-        target_dir = Path.cwd() / "remote-ns"
+        target_dir = Path.cwd() / "remote-instance-name"
         assert (target_dir / "backend.tf").exists()
         backend_content = (target_dir / "backend.tf").read_text()
         assert 'bucket = "mock-bucket-name"' in backend_content
@@ -443,7 +445,7 @@ def test_init_uses_default_ref_v_prefixed(
         'variable "test" {}',
         'module "stack" {\n  source = "./modules/stack"\n}',
         'output "test" {}',
-        'project_id = "$$PROJECT_ID$$"\nnamespace  = "$$NAMESPACE$$"\n# dc_api_key = "$$DC_API_KEY$$"',
+        'project_id = "$$PROJECT_ID$$"\ninstance_name  = "$$INSTANCE_NAME$$"\n# dc_api_key = "$$DC_API_KEY$$"',
     )
     from datacommons_admin import __version__
 
@@ -454,8 +456,8 @@ def test_init_uses_default_ref_v_prefixed(
                 "init",
                 "--project-id",
                 "ref-project",
-                "--namespace",
-                "ref-ns",
+                "--instance-name",
+                "ref-instance-name",
                 "--dc-api-key",
                 "ref-key",
                 "--no-tf-remote-state",

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -44,7 +44,7 @@ def test_init_success_with_options(
                 "--project-id",
                 "test-project",
                 "--instance-name",
-                "test-instance-name",
+                "test-instance",
                 "--dc-api-key",
                 "test-key",
                 "--no-tf-remote-state",
@@ -53,7 +53,7 @@ def test_init_success_with_options(
         assert result.exit_code == 0
         assert "Downloaded and populated Terraform templates." in result.output
 
-        target_dir = Path.cwd() / "test-instance-name"
+        target_dir = Path.cwd() / "test-instance"
         assert target_dir.exists()
         assert (target_dir / "main.tf").exists()
         assert (target_dir / "terraform.tfvars").exists()
@@ -62,7 +62,7 @@ def test_init_success_with_options(
 
         tfvars_content = (target_dir / "terraform.tfvars").read_text()
         assert 'project_id = "test-project"' in tfvars_content
-        assert 'instance_name  = "test-instance-name"' in tfvars_content
+        assert 'instance_name  = "test-instance"' in tfvars_content
         assert 'dc_api_key = "test-key"' in tfvars_content
 
 
@@ -80,15 +80,15 @@ def test_init_success_with_prompts(
         result = runner.invoke(
             admin,
             ["init", "--no-tf-remote-state"],
-            input="prompt-project\nprompt-instance-name\nprompt-key\n",
+            input="prompt-project\nprompt-instance\nprompt-key\n",
         )
         assert result.exit_code == 0
-        target_dir = Path.cwd() / "prompt-instance-name"
+        target_dir = Path.cwd() / "prompt-instance"
         assert target_dir.exists()
 
         tfvars_content = (target_dir / "terraform.tfvars").read_text()
         assert 'project_id = "prompt-project"' in tfvars_content
-        assert 'instance_name  = "prompt-instance-name"' in tfvars_content
+        assert 'instance_name  = "prompt-instance"' in tfvars_content
 
 
 @patch("datacommons_admin.admin_cli._get_github_templates")
@@ -102,7 +102,7 @@ def test_init_existing_folder_force(
         'project_id = "$$PROJECT_ID$$"\ninstance_name  = "$$INSTANCE_NAME$$"\n# dc_api_key = "$$DC_API_KEY$$"',
     )
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        existing_dir = Path.cwd() / "existing-instance-name"
+        existing_dir = Path.cwd() / "existing-dcp"
         existing_dir.mkdir()
         (existing_dir / "main.tf").write_text("old content")
 
@@ -113,7 +113,7 @@ def test_init_existing_folder_force(
                 "--project-id",
                 "test-project",
                 "--instance-name",
-                "existing-instance-name",
+                "existing-dcp",
                 "--force",
                 "--no-tf-remote-state",
             ],
@@ -148,17 +148,17 @@ def test_init_remote_state(
                 "--project-id",
                 "remote-project",
                 "--instance-name",
-                "remote-instance-name",
+                "remote-instance",
                 "--dc-api-key",
                 "remote-key",
             ],
         )
         assert result.exit_code == 0
         mock_configure.assert_called_once_with(
-            "remote-project", "remote-instance-name", "", "US"
+            "remote-project", "remote-instance", "", "US"
         )
 
-        target_dir = Path.cwd() / "remote-instance-name"
+        target_dir = Path.cwd() / "remote-instance"
         assert (target_dir / "backend.tf").exists()
         backend_content = (target_dir / "backend.tf").read_text()
         assert 'bucket = "mock-bucket-name"' in backend_content
@@ -457,7 +457,7 @@ def test_init_uses_default_ref_v_prefixed(
                 "--project-id",
                 "ref-project",
                 "--instance-name",
-                "ref-instance-name",
+                "ref-instance",
                 "--dc-api-key",
                 "ref-key",
                 "--no-tf-remote-state",

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -53,7 +53,7 @@ def test_init_success_with_options(
         assert result.exit_code == 0
         assert "Downloaded and populated Terraform templates." in result.output
 
-        target_dir = Path.cwd() / "test-ns"
+        target_dir = Path.cwd() / "test-instance-name"
         assert target_dir.exists()
         assert (target_dir / "main.tf").exists()
         assert (target_dir / "terraform.tfvars").exists()

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -67,6 +67,38 @@ def test_init_success_with_options(
 
 
 @patch("datacommons_admin.admin_cli._get_github_templates")
+def test_init_success_with_deprecated_namespace_flag(
+    mock_get_templates, runner: CliRunner, tmp_path: Path
+) -> None:
+    mock_get_templates.return_value = (
+        'variable "test" {}',
+        'module "stack" {\n  source = "./modules/stack"\n}',
+        'output "test" {}',
+        'project_id = "$$PROJECT_ID$$"\ninstance_name  = "$$INSTANCE_NAME$$"\n# dc_api_key = "$$DC_API_KEY$$"',
+    )
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(
+            admin,
+            [
+                "init",
+                "--project-id",
+                "test-project",
+                "--namespace",
+                "legacy-namespace",
+                "--dc-api-key",
+                "test-key",
+                "--no-tf-remote-state",
+            ],
+        )
+        assert result.exit_code == 0
+        target_dir = Path.cwd() / "legacy-namespace"
+        assert target_dir.exists()
+        tfvars_content = (target_dir / "terraform.tfvars").read_text()
+        assert 'instance_name  = "legacy-namespace"' in tfvars_content
+
+
+
+@patch("datacommons_admin.admin_cli._get_github_templates")
 def test_init_success_with_prompts(
     mock_get_templates, runner: CliRunner, tmp_path: Path
 ) -> None:

--- a/packages/datacommons-admin/tests/test_admin_cli.py
+++ b/packages/datacommons-admin/tests/test_admin_cli.py
@@ -97,7 +97,6 @@ def test_init_success_with_deprecated_namespace_flag(
         assert 'instance_name  = "legacy-namespace"' in tfvars_content
 
 
-
 @patch("datacommons_admin.admin_cli._get_github_templates")
 def test_init_success_with_prompts(
     mock_get_templates, runner: CliRunner, tmp_path: Path

--- a/packages/datacommons-cli/README.md
+++ b/packages/datacommons-cli/README.md
@@ -95,7 +95,7 @@ datacommons admin [COMMAND] --help
 
 1. Initialize your project configuration and scaffold Terraform templates:
    ```bash
-   datacommons admin init --project-id my-gcp-project --namespace prod
+   datacommons admin init --project-id my-gcp-project --instance-name prod
    ```
 
 2. Change directories to the scaffolded directory (e.g. `cd prod`).

--- a/tests/datacommons-integration-tests/README.md
+++ b/tests/datacommons-integration-tests/README.md
@@ -74,15 +74,15 @@ Pulls the latest templates, provisions a completely new isolated sandbox stack i
   ```
 
 #### 2. Lightweight Mode (Fast Debugging Loop)
-Skips the slow Terraform setup and teardown stages entirely. It reads resource configurations from an existing `/tmp/workspace-<namespace>` directory, clears the database tables, re-uploads local test data files, triggers the ingestion workflow, and runs `pytest`. This reduces iteration time **from 10+ minutes down to 1-2 minutes**.
+Skips the slow Terraform setup and teardown stages entirely. It reads resource configurations from an existing `/tmp/workspace-<instance-name>` directory, clears the database tables, re-uploads local test data files, triggers the ingestion workflow, and runs `pytest`. This reduces iteration time **from 10+ minutes down to 1-2 minutes**.
 * **Usage:**
   1. First, create a persistent sandbox and keep it alive:
      ```bash
-     uv run python tests/datacommons-integration-tests/gcp_test_runner.py --namespace my-debug-sandbox --keep-sandbox
+     uv run python tests/datacommons-integration-tests/gcp_test_runner.py --instance-name my-debug-sandbox --keep-sandbox
      ```
   2. Run subsequent test runs in lightweight mode:
      ```bash
-     uv run python tests/datacommons-integration-tests/gcp_test_runner.py --namespace my-debug-sandbox --reuse-sandbox
+     uv run python tests/datacommons-integration-tests/gcp_test_runner.py --instance-name my-debug-sandbox --reuse-sandbox
      ```
 
 
@@ -90,9 +90,9 @@ Skips the slow Terraform setup and teardown stages entirely. It reads resource c
 *   `--project-id`: The Google Cloud Project ID where the sandbox resources should be provisioned (default: `datcom-ci`).
 *   `--dc-api-key`: Google Data Commons API Key needed to authenticate and configure sandbox clients.
 *   `--region`: The GCP region to deploy resources (default: `us-central1`).
-*   `--namespace`: Custom naming namespace for resources (default: randomized `itest-XXXX`).
+*   `--instance-name`: Custom naming instance name for resources (default: randomized `itest-XXXX`).
 *   `--keep-sandbox`: Do not destroy sandbox GCP resources on completion/failure. Useful for debugging active instances.
-*   `--reuse-sandbox`: Reuse existing local workspace and GCP sandbox resources if they exist. Requires passing a persistent, custom `--namespace` (e.g. `--namespace itest-9611`) and having run with `--keep-sandbox` in the previous run.
+*   `--reuse-sandbox`: Reuse existing local workspace and GCP sandbox resources if they exist. Requires passing a persistent, custom `--instance-name` (e.g. `--instance-name itest-9611`) and having run with `--keep-sandbox` in the previous run.
 *   `--tf-git-ref`: Git reference branch/tag/commit for the GCP Terraform templates repository (default: `main`).
 *   `--dcp-version`: Override default DCP version (controls all images and templates) (default: `latest`).
 

--- a/tests/datacommons-integration-tests/gcp_test_runner.py
+++ b/tests/datacommons-integration-tests/gcp_test_runner.py
@@ -154,7 +154,7 @@ def setup_workspace(workspace_dir: Path, instance_name: str) -> None:
                 )
                 if is_ci:
                     raise RuntimeError(
-                        f"Aborting to prevent resource leakage. Clean up resources for namespace '{instance_name}' manually."
+                        f"Aborting to prevent resource leakage. Clean up resources for sandbox '{instance_name}' manually."
                     ) from e
                 print(
                     "\n[!] WARNING: Deleting this directory will permanently orphan these resources in GCP.",

--- a/tests/datacommons-integration-tests/gcp_test_runner.py
+++ b/tests/datacommons-integration-tests/gcp_test_runner.py
@@ -118,11 +118,11 @@ def validate_mcf_file(mcf_path: Path) -> None:
         ) from e
 
 
-def setup_workspace(workspace_dir: Path, namespace: str) -> None:
+def setup_workspace(workspace_dir: Path, instance_name: str) -> None:
     """Ensure clean scratch workspace directories exist.
     Tries to destroy resources first if tfstate is present to avoid leakage.
     """
-    sandbox_dir = workspace_dir / namespace
+    sandbox_dir = workspace_dir / instance_name
     if sandbox_dir.exists() and (sandbox_dir / "terraform.tfstate").exists():
         has_resources = False
         try:
@@ -136,7 +136,7 @@ def setup_workspace(workspace_dir: Path, namespace: str) -> None:
 
         if has_resources:
             logging.info(
-                f">>> [STEP] Existing active sandbox '{namespace}' detected with provisioned resources."
+                f">>> [STEP] Existing active sandbox '{instance_name}' detected with provisioned resources."
             )
             logging.info(
                 ">>> [STEP] Attempting to clean up existing GCP resources first..."
@@ -154,7 +154,7 @@ def setup_workspace(workspace_dir: Path, namespace: str) -> None:
                 )
                 if is_ci:
                     raise RuntimeError(
-                        f"Aborting to prevent resource leakage. Clean up resources for namespace '{namespace}' manually."
+                        f"Aborting to prevent resource leakage. Clean up resources for namespace '{instance_name}' manually."
                     ) from e
                 print(
                     "\n[!] WARNING: Deleting this directory will permanently orphan these resources in GCP.",
@@ -184,7 +184,7 @@ def initialize_sandbox_scaffolding(
     workspace_root: Path,
     workspace_dir: Path,
     project_id: str,
-    namespace: str,
+    instance_name: str,
     dc_api_key: str,
     tf_git_ref: str,
     tf_state_bucket: str = "",
@@ -201,8 +201,8 @@ def initialize_sandbox_scaffolding(
         "init",
         "--project-id",
         project_id,
-        "--namespace",
-        namespace,
+        "--instance-name",
+        instance_name,
         "--dc-api-key",
         dc_api_key,
     ]
@@ -215,7 +215,7 @@ def initialize_sandbox_scaffolding(
         init_args.extend(["--tf-git-ref", tf_git_ref])
 
     run_command(init_args, cwd=workspace_dir)
-    sandbox_dir = workspace_dir / namespace
+    sandbox_dir = workspace_dir / instance_name
     log_success(f"Sandbox created at {sandbox_dir}")
 
     # Overwrite remote github scaffolding with local workspace files to test local modifications offline
@@ -704,9 +704,9 @@ def main() -> None:
         "--region", default="us-central1", help="GCP region to deploy in"
     )
     parser.add_argument(
-        "--namespace",
+        "--instance-name",
         default=None,
-        help="Custom namespace (defaults to itest-XXXX)",
+        help="Custom instance name (defaults to itest-XXXX)",
     )
     parser.add_argument(
         "--dcp-version",
@@ -742,15 +742,15 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # Generate random namespace if not provided
-    namespace = args.namespace
-    if not namespace:
+    # Generate random instance name if not provided
+    instance_name = args.instance_name
+    if not instance_name:
         rand_suffix = f"{random.randint(1000, 9999)}"
-        namespace = f"itest-{rand_suffix}"
+        instance_name = f"itest-{rand_suffix}"
 
-    log_step(f"Starting Integration Test with namespace: {namespace}")
+    log_step(f"Starting Integration Test with instance name: {instance_name}")
 
-    workspace_dir = Path(f"/tmp/workspace-{namespace}")
+    workspace_dir = Path(f"/tmp/workspace-{instance_name}")
     workspace_root = Path(__file__).resolve().parent.parent.parent
 
     # Track lifecycle state for cleanups
@@ -759,18 +759,18 @@ def main() -> None:
 
     try:
         if args.reuse_sandbox:
-            if not args.namespace:
+            if not args.instance_name:
                 raise RuntimeError(
-                    "Namespace must be specified when using --reuse-sandbox (e.g. --namespace itest-XXXX)"
+                    "Instance name must be specified when using --reuse-sandbox (e.g. --instance-name itest-XXXX)"
                 )
-            sandbox_dir = workspace_dir / namespace
+            sandbox_dir = workspace_dir / instance_name
             if not sandbox_dir.exists():
                 raise RuntimeError(f"Sandbox directory does not exist: {sandbox_dir}")
-            log_step(f"Reusing existing sandbox namespace: {namespace}")
+            log_step(f"Reusing existing sandbox instance name: {instance_name}")
             outputs = get_terraform_outputs(sandbox_dir)
         else:
             # 1. Setup workspace
-            setup_workspace(workspace_dir, namespace)
+            setup_workspace(workspace_dir, instance_name)
 
             # 1b. Validate local MCF schema syntax before deploying expensive cloud resources
             root_dir = Path(__file__).resolve().parent.parent.parent
@@ -790,7 +790,7 @@ def main() -> None:
                 workspace_root=workspace_root,
                 workspace_dir=workspace_dir,
                 project_id=args.project_id,
-                namespace=namespace,
+                instance_name=instance_name,
                 dc_api_key=dc_key,
                 tf_git_ref=args.tf_git_ref,
                 tf_state_bucket=args.tf_state_bucket,
@@ -858,7 +858,7 @@ def main() -> None:
         if terraform_provisioned and sandbox_dir:
             if args.keep_sandbox:
                 log_step(
-                    f"Keeping GCP Sandbox intact for debugging: namespace={namespace}"
+                    f"Keeping GCP Sandbox intact for debugging: instance_name={instance_name}"
                 )
             else:
                 run_terraform_destroy(sandbox_dir, workspace_dir)

--- a/tests/datacommons-integration-tests/gcp_test_runner.py
+++ b/tests/datacommons-integration-tests/gcp_test_runner.py
@@ -705,8 +705,10 @@ def main() -> None:
     )
     parser.add_argument(
         "--instance-name",
+        "--namespace",
+        dest="instance_name",
         default=None,
-        help="Custom instance name (defaults to itest-XXXX)",
+        help="Custom instance name (defaults to itest-XXXX). (Deprecated alias: --namespace)",
     )
     parser.add_argument(
         "--dcp-version",


### PR DESCRIPTION
# Rename Namespace to Instance Name in Deployment script

Per the spec in [this design doc](https://docs.google.com/document/d/1P4tLdXHJcGzMnTMU8D-mLMn2iD-omWwPRdtf_PGD4OA/edit?pli=1&tab=t.wfjs67bl2yqu#heading=h.8s8k7s5ndtev) (Google corp access required), we are renaming "namespace" to "instance name" to reduce confusion between the instance prefix and schema namespaces.

This PR updates the canonical `datacommons admin init` syntax.

Before:
```
uvx datacommons-cli admin init \
  --namespace "some-string"
```

After:
```
uvx datacommons-cli admin init \
  --instance-name "some-string"
```

Note that the "before" syntax is still supported to maintain backwards compatibility.
 
More specifically, this PR makes the following changes:
* Updates the `--namespace` flag to `--instance-name`
* Updates terraform files to use the variable `instance_name` instead of `namespace`
* Renames `instance_name` in the context of Redis caching to `redis_instance_name` to avoid naming collision.
* Updates tests to reflect these changes
* Updates READMEs, and CLI messages to reflect these changes

## Testing Strategy

Beyond CI Checks, I also ran though commands manually, making sure that generated files are correct, there were no errors, and DCP deploys successfully.


First, I temporarily updated the hardcoded Git repo urls to point to my fork so that my version of .tf files get used.

Then I tried the following commands:

Test the default init step:
```
uv run datacommons admin init --tf-git-ref <my-remote-branch-name>
terraform init
terraform apply
```

Test the init step with arguments passed in:
```
uv run datacommons admin init --tf-git-ref <my-remote-branch-name> \
  --instance_name <my-test-instance-name>
terraform init
terraform apply 
```

Test that the old syntax still works, for backwards compatibility
```
uv run datacommons admin init --tf-git-ref <my-remote-branch-name> \
  --namespace <my-test-instance-name>
terraform init
terraform apply
```

Test that ingestion pipeline still works, via the frog dataset
```
# After copying frog_data to my GCS bucket
uv run datacommons admin init-db
uv run datacommons admin ingest start --imports frog_data
```
