### PR TITLE
[terraform] remove BigQuery connection and IAM permissions from ingestion helper service

### DIFF
--- a/infra/dcp/modules/ingestion/helper_service/main.tf
+++ b/infra/dcp/modules/ingestion/helper_service/main.tf
@@ -43,10 +43,6 @@ resource "google_cloud_run_v2_service" "ingestion_helper" {
         name  = "SPANNER_GRAPH_DATABASE_ID"
         value = var.spanner_database_id
       }
-      env {
-        name  = "BQ_SPANNER_CONN_ID"
-        value = var.bigquery_connection_id
-      }
 
       env {
         name  = "LOCATION"
@@ -108,25 +104,6 @@ resource "google_storage_bucket_iam_member" "helper_bucket_access" {
   bucket = var.ingestion_bucket_name
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.helper_sa[0].email}"
-}
-
-resource "google_project_iam_member" "helper_bq_roles" {
-  for_each = toset(var.deploy && var.enable_bigquery_postprocessing ? [
-    "roles/bigquery.dataEditor",
-    "roles/bigquery.jobUser"
-  ] : [])
-  project = var.project_id
-  role    = each.value
-  member  = "serviceAccount:${google_service_account.helper_sa[0].email}"
-}
-
-resource "google_bigquery_connection_iam_member" "helper_connection_user" {
-  count         = var.deploy && var.enable_bigquery_connection ? 1 : 0
-  project       = var.project_id
-  location      = var.region
-  connection_id = var.bigquery_connection_id
-  role          = "roles/bigquery.connectionUser"
-  member        = "serviceAccount:${google_service_account.helper_sa[0].email}"
 }
 
 resource "google_project_iam_member" "helper_dataflow_viewer" {

--- a/infra/dcp/modules/ingestion/helper_service/variables.tf
+++ b/infra/dcp/modules/ingestion/helper_service/variables.tf
@@ -37,27 +37,11 @@ variable "image" {
   description = "Docker image URL for the ingestion support service"
 }
 
-variable "bigquery_connection_id" {
-  type    = string
-  default = ""
-}
-
 variable "use_spanner" {
   type    = bool
   default = true
 }
 
-variable "enable_bigquery_connection" {
-  type        = bool
-  description = "Flag to enable BigQuery connection usage"
-  default     = false
-}
-
-variable "enable_bigquery_postprocessing" {
-  type        = bool
-  description = "Flag to enable BigQuery postprocessing"
-  default     = true
-}
 
 variable "enable_embeddings_generation" {
   type        = bool

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -186,15 +186,12 @@ module "ingestion_helper_service" {
   region                        = var.global.region
   stateless_deletion_protection = var.global.stateless_deletion_protection
   # Use index [0] because module.spanner is conditional. Fallback to empty string if disabled.
-  spanner_instance_id            = var.spanner_config.enable ? module.spanner[0].spanner_instance_id : ""
-  spanner_database_id            = var.spanner_config.enable ? module.spanner[0].spanner_database_id : ""
-  bigquery_connection_id         = var.spanner_config.enable ? module.spanner[0].bigquery_connection_id : ""
-  ingestion_bucket_name          = module.storage.artifacts_bucket_name
-  image                          = var.ingestion_config.helper_service_image
-  use_spanner                    = var.spanner_config.enable
-  enable_bigquery_postprocessing = var.ingestion_config.workflow_enable_bigquery_postprocessing
-  enable_bigquery_connection     = var.spanner_config.enable_bigquery_connection
-  enable_embeddings_generation   = var.spanner_config.enable_embeddings_generation
+  spanner_instance_id          = var.spanner_config.enable ? module.spanner[0].spanner_instance_id : ""
+  spanner_database_id          = var.spanner_config.enable ? module.spanner[0].spanner_database_id : ""
+  ingestion_bucket_name        = module.storage.artifacts_bucket_name
+  image                        = var.ingestion_config.helper_service_image
+  use_spanner                  = var.spanner_config.enable
+  enable_embeddings_generation = var.spanner_config.enable_embeddings_generation
 
   # Redis configuration for cache clearing
   vpc_connector_id         = var.redis_config.enable && length(module.redis) > 0 ? module.redis[0].connector_id : null


### PR DESCRIPTION
### Summary of Changes

Removes legacy BigQuery configuration and permissions from `ingestion_helper_service` in Terraform, as postprocessing / BigQuery federated aggregation during ingestion is now executed by a dedicated Cloud Run Job (`postprocessing_job`).

1. **`infra/dcp/modules/ingestion/helper_service/main.tf`**:
   - Removed `BQ_SPANNER_CONN_ID` environment variable from container configuration.
   - Removed `helper_bq_roles` (`roles/bigquery.dataEditor`, `roles/bigquery.jobUser`) and `helper_connection_user` (`roles/bigquery.connectionUser`) IAM bindings for `dc-ing-hlp-sa`.

2. **`infra/dcp/modules/ingestion/helper_service/variables.tf`**:
   - Removed unused module variables: `bigquery_connection_id`, `enable_bigquery_connection`, and `enable_bigquery_postprocessing`.

3. **`infra/dcp/modules/stack/main.tf`**:
   - Removed `bigquery_connection_id`, `enable_bigquery_postprocessing`, and `enable_bigquery_connection` arguments from the `module "ingestion_helper_service"` block.