### PR TITLE
[terraform] propagate V2_RESOLVE_INDICATORS_TARGET to website service

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -87,21 +87,21 @@ locals {
   }
 
   datacommons_services_config = {
-    enable                            = var.enable_datacommons_services
-    image                             = coalesce(var.datacommons_services_image, "gcr.io/datcom-ci/datacommons-services:${var.dcp_version}")
-    name                              = var.datacommons_services_name
-    min_instances                     = var.datacommons_services_min_instances
-    max_instances                     = var.datacommons_services_max_instances
-    cpu                               = var.datacommons_services_cpu
-    memory                            = var.datacommons_services_memory
-    google_analytics_tag              = var.datacommons_services_google_analytics_tag_id
-    enable_mcp                        = var.datacommons_services_enable_mcp
-    search_scope                      = var.datacommons_services_mcp_search_scope
-    instructions_path                 = var.datacommons_services_mcp_instructions_path != null ? trimsuffix(var.datacommons_services_mcp_instructions_path, "/") : null
-    allow_unauthenticated_access      = var.datacommons_services_allow_unauthenticated_access
-    website_disable_google_maps_api   = var.datacommons_services_website_disable_google_maps_api
-    resolve_with_spanner_embeddings   = var.datacommons_services_resolve_with_spanner_embeddings
-    website_resolve_indicators_target = var.datacommons_services_website_resolve_indicators_target
+    enable                          = var.enable_datacommons_services
+    image                           = coalesce(var.datacommons_services_image, "gcr.io/datcom-ci/datacommons-services:${var.dcp_version}")
+    name                            = var.datacommons_services_name
+    min_instances                   = var.datacommons_services_min_instances
+    max_instances                   = var.datacommons_services_max_instances
+    cpu                             = var.datacommons_services_cpu
+    memory                          = var.datacommons_services_memory
+    google_analytics_tag            = var.datacommons_services_google_analytics_tag_id
+    enable_mcp                      = var.datacommons_services_enable_mcp
+    search_scope                    = var.datacommons_services_mcp_search_scope
+    instructions_path               = var.datacommons_services_mcp_instructions_path != null ? trimsuffix(var.datacommons_services_mcp_instructions_path, "/") : null
+    allow_unauthenticated_access    = var.datacommons_services_allow_unauthenticated_access
+    website_disable_google_maps_api = var.datacommons_services_website_disable_google_maps_api
+    resolve_with_spanner_embeddings = var.datacommons_services_resolve_with_spanner_embeddings
+    website_search_scope            = var.datacommons_services_website_search_scope
   }
 
   auth_config = {

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -101,6 +101,7 @@ locals {
     allow_unauthenticated_access    = var.datacommons_services_allow_unauthenticated_access
     website_disable_google_maps_api = var.datacommons_services_website_disable_google_maps_api
     resolve_with_spanner_embeddings = var.datacommons_services_resolve_with_spanner_embeddings
+    v2_resolve_indicators_target    = var.datacommons_services_v2_resolve_indicators_target
   }
 
   auth_config = {

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -87,21 +87,21 @@ locals {
   }
 
   datacommons_services_config = {
-    enable                          = var.enable_datacommons_services
-    image                           = coalesce(var.datacommons_services_image, "gcr.io/datcom-ci/datacommons-services:${var.dcp_version}")
-    name                            = var.datacommons_services_name
-    min_instances                   = var.datacommons_services_min_instances
-    max_instances                   = var.datacommons_services_max_instances
-    cpu                             = var.datacommons_services_cpu
-    memory                          = var.datacommons_services_memory
-    google_analytics_tag            = var.datacommons_services_google_analytics_tag_id
-    enable_mcp                      = var.datacommons_services_enable_mcp
-    search_scope                    = var.datacommons_services_mcp_search_scope
-    instructions_path               = var.datacommons_services_mcp_instructions_path != null ? trimsuffix(var.datacommons_services_mcp_instructions_path, "/") : null
-    allow_unauthenticated_access    = var.datacommons_services_allow_unauthenticated_access
-    website_disable_google_maps_api = var.datacommons_services_website_disable_google_maps_api
-    resolve_with_spanner_embeddings = var.datacommons_services_resolve_with_spanner_embeddings
-    v2_resolve_indicators_target    = var.datacommons_services_v2_resolve_indicators_target
+    enable                               = var.enable_datacommons_services
+    image                                = coalesce(var.datacommons_services_image, "gcr.io/datcom-ci/datacommons-services:${var.dcp_version}")
+    name                                 = var.datacommons_services_name
+    min_instances                        = var.datacommons_services_min_instances
+    max_instances                        = var.datacommons_services_max_instances
+    cpu                                  = var.datacommons_services_cpu
+    memory                               = var.datacommons_services_memory
+    google_analytics_tag                 = var.datacommons_services_google_analytics_tag_id
+    enable_mcp                           = var.datacommons_services_enable_mcp
+    search_scope                         = var.datacommons_services_mcp_search_scope
+    instructions_path                    = var.datacommons_services_mcp_instructions_path != null ? trimsuffix(var.datacommons_services_mcp_instructions_path, "/") : null
+    allow_unauthenticated_access         = var.datacommons_services_allow_unauthenticated_access
+    website_disable_google_maps_api      = var.datacommons_services_website_disable_google_maps_api
+    resolve_with_spanner_embeddings      = var.datacommons_services_resolve_with_spanner_embeddings
+    website_v2_resolve_indicators_target = var.datacommons_services_website_v2_resolve_indicators_target
   }
 
   auth_config = {

--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -87,21 +87,21 @@ locals {
   }
 
   datacommons_services_config = {
-    enable                               = var.enable_datacommons_services
-    image                                = coalesce(var.datacommons_services_image, "gcr.io/datcom-ci/datacommons-services:${var.dcp_version}")
-    name                                 = var.datacommons_services_name
-    min_instances                        = var.datacommons_services_min_instances
-    max_instances                        = var.datacommons_services_max_instances
-    cpu                                  = var.datacommons_services_cpu
-    memory                               = var.datacommons_services_memory
-    google_analytics_tag                 = var.datacommons_services_google_analytics_tag_id
-    enable_mcp                           = var.datacommons_services_enable_mcp
-    search_scope                         = var.datacommons_services_mcp_search_scope
-    instructions_path                    = var.datacommons_services_mcp_instructions_path != null ? trimsuffix(var.datacommons_services_mcp_instructions_path, "/") : null
-    allow_unauthenticated_access         = var.datacommons_services_allow_unauthenticated_access
-    website_disable_google_maps_api      = var.datacommons_services_website_disable_google_maps_api
-    resolve_with_spanner_embeddings      = var.datacommons_services_resolve_with_spanner_embeddings
-    website_v2_resolve_indicators_target = var.datacommons_services_website_v2_resolve_indicators_target
+    enable                            = var.enable_datacommons_services
+    image                             = coalesce(var.datacommons_services_image, "gcr.io/datcom-ci/datacommons-services:${var.dcp_version}")
+    name                              = var.datacommons_services_name
+    min_instances                     = var.datacommons_services_min_instances
+    max_instances                     = var.datacommons_services_max_instances
+    cpu                               = var.datacommons_services_cpu
+    memory                            = var.datacommons_services_memory
+    google_analytics_tag              = var.datacommons_services_google_analytics_tag_id
+    enable_mcp                        = var.datacommons_services_enable_mcp
+    search_scope                      = var.datacommons_services_mcp_search_scope
+    instructions_path                 = var.datacommons_services_mcp_instructions_path != null ? trimsuffix(var.datacommons_services_mcp_instructions_path, "/") : null
+    allow_unauthenticated_access      = var.datacommons_services_allow_unauthenticated_access
+    website_disable_google_maps_api   = var.datacommons_services_website_disable_google_maps_api
+    resolve_with_spanner_embeddings   = var.datacommons_services_resolve_with_spanner_embeddings
+    website_resolve_indicators_target = var.datacommons_services_website_resolve_indicators_target
   }
 
   auth_config = {

--- a/infra/dcp/modules/datacommons_services/main.tf
+++ b/infra/dcp/modules/datacommons_services/main.tf
@@ -113,6 +113,10 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
         name  = "USE_SPANNER_KEY_VALUE_STORE"
         value = var.use_spanner ? "true" : "false"
       }
+      env {
+        name  = "V2_RESOLVE_INDICATORS_TARGET"
+        value = var.v2_resolve_indicators_target
+      }
     }
 
     dynamic "vpc_access" {

--- a/infra/dcp/modules/datacommons_services/main.tf
+++ b/infra/dcp/modules/datacommons_services/main.tf
@@ -115,7 +115,7 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
       }
       env {
         name  = "V2_RESOLVE_INDICATORS_TARGET"
-        value = var.v2_resolve_indicators_target
+        value = var.website_v2_resolve_indicators_target
       }
     }
 

--- a/infra/dcp/modules/datacommons_services/main.tf
+++ b/infra/dcp/modules/datacommons_services/main.tf
@@ -115,7 +115,7 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
       }
       env {
         name  = "V2_RESOLVE_INDICATORS_TARGET"
-        value = var.website_v2_resolve_indicators_target
+        value = var.website_resolve_indicators_target
       }
     }
 

--- a/infra/dcp/modules/datacommons_services/main.tf
+++ b/infra/dcp/modules/datacommons_services/main.tf
@@ -115,7 +115,7 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
       }
       env {
         name  = "V2_RESOLVE_INDICATORS_TARGET"
-        value = var.website_resolve_indicators_target
+        value = var.website_search_scope
       }
     }
 

--- a/infra/dcp/modules/datacommons_services/variables.tf
+++ b/infra/dcp/modules/datacommons_services/variables.tf
@@ -73,10 +73,10 @@ variable "resolve_with_spanner_embeddings" {
   type = bool
 }
 
-variable "website_resolve_indicators_target" {
+variable "website_search_scope" {
   type        = string
   default     = ""
-  description = "Target parameter for indicator v2/resolve calls made by website service"
+  description = "Controls the scope for indicator resolution on the website Explore page"
 }
 
 # =============================================================================

--- a/infra/dcp/modules/datacommons_services/variables.tf
+++ b/infra/dcp/modules/datacommons_services/variables.tf
@@ -73,7 +73,7 @@ variable "resolve_with_spanner_embeddings" {
   type = bool
 }
 
-variable "v2_resolve_indicators_target" {
+variable "website_v2_resolve_indicators_target" {
   type        = string
   default     = ""
   description = "Target parameter for indicator v2/resolve calls made by website service"

--- a/infra/dcp/modules/datacommons_services/variables.tf
+++ b/infra/dcp/modules/datacommons_services/variables.tf
@@ -73,6 +73,12 @@ variable "resolve_with_spanner_embeddings" {
   type = bool
 }
 
+variable "v2_resolve_indicators_target" {
+  type        = string
+  default     = ""
+  description = "Target parameter for indicator v2/resolve calls made by website service"
+}
+
 # =============================================================================
 # Infrastructure References
 # =============================================================================

--- a/infra/dcp/modules/datacommons_services/variables.tf
+++ b/infra/dcp/modules/datacommons_services/variables.tf
@@ -73,7 +73,7 @@ variable "resolve_with_spanner_embeddings" {
   type = bool
 }
 
-variable "website_v2_resolve_indicators_target" {
+variable "website_resolve_indicators_target" {
   type        = string
   default     = ""
   description = "Target parameter for indicator v2/resolve calls made by website service"

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -283,9 +283,9 @@ module "datacommons_services" {
       value = module.ingestion_workflow.workflow_name != null ? module.ingestion_workflow.workflow_name : ""
     }
   ])
-  secret_env_vars                 = local.datacommons_services_secrets
-  resolve_with_spanner_embeddings = var.datacommons_services_config.resolve_with_spanner_embeddings
-  v2_resolve_indicators_target    = var.datacommons_services_config.v2_resolve_indicators_target
+  secret_env_vars                      = local.datacommons_services_secrets
+  resolve_with_spanner_embeddings      = var.datacommons_services_config.resolve_with_spanner_embeddings
+  website_v2_resolve_indicators_target = var.datacommons_services_config.website_v2_resolve_indicators_target
 
   depends_on = [module.ingestion_preprocessing_job]
 }

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -283,9 +283,9 @@ module "datacommons_services" {
       value = module.ingestion_workflow.workflow_name != null ? module.ingestion_workflow.workflow_name : ""
     }
   ])
-  secret_env_vars                   = local.datacommons_services_secrets
-  resolve_with_spanner_embeddings   = var.datacommons_services_config.resolve_with_spanner_embeddings
-  website_resolve_indicators_target = var.datacommons_services_config.website_resolve_indicators_target
+  secret_env_vars                 = local.datacommons_services_secrets
+  resolve_with_spanner_embeddings = var.datacommons_services_config.resolve_with_spanner_embeddings
+  website_search_scope            = var.datacommons_services_config.website_search_scope
 
   depends_on = [module.ingestion_preprocessing_job]
 }

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -285,6 +285,7 @@ module "datacommons_services" {
   ])
   secret_env_vars                 = local.datacommons_services_secrets
   resolve_with_spanner_embeddings = var.datacommons_services_config.resolve_with_spanner_embeddings
+  v2_resolve_indicators_target    = var.datacommons_services_config.v2_resolve_indicators_target
 
   depends_on = [module.ingestion_preprocessing_job]
 }

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -283,9 +283,9 @@ module "datacommons_services" {
       value = module.ingestion_workflow.workflow_name != null ? module.ingestion_workflow.workflow_name : ""
     }
   ])
-  secret_env_vars                      = local.datacommons_services_secrets
-  resolve_with_spanner_embeddings      = var.datacommons_services_config.resolve_with_spanner_embeddings
-  website_v2_resolve_indicators_target = var.datacommons_services_config.website_v2_resolve_indicators_target
+  secret_env_vars                   = local.datacommons_services_secrets
+  resolve_with_spanner_embeddings   = var.datacommons_services_config.resolve_with_spanner_embeddings
+  website_resolve_indicators_target = var.datacommons_services_config.website_resolve_indicators_target
 
   depends_on = [module.ingestion_preprocessing_job]
 }

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -37,21 +37,21 @@ variable "spanner_config" {
 
 variable "datacommons_services_config" {
   type = object({
-    enable                          = bool
-    image                           = optional(string)
-    name                            = string
-    min_instances                   = number
-    max_instances                   = number
-    cpu                             = string
-    memory                          = string
-    google_analytics_tag            = string
-    enable_mcp                      = bool
-    search_scope                    = string
-    instructions_path               = string
-    allow_unauthenticated_access    = bool
-    website_disable_google_maps_api = bool
-    resolve_with_spanner_embeddings = bool
-    v2_resolve_indicators_target    = optional(string, "")
+    enable                               = bool
+    image                                = optional(string)
+    name                                 = string
+    min_instances                        = number
+    max_instances                        = number
+    cpu                                  = string
+    memory                               = string
+    google_analytics_tag                 = string
+    enable_mcp                           = bool
+    search_scope                         = string
+    instructions_path                    = string
+    allow_unauthenticated_access         = bool
+    website_disable_google_maps_api      = bool
+    resolve_with_spanner_embeddings      = bool
+    website_v2_resolve_indicators_target = optional(string, "")
   })
 }
 

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -51,6 +51,7 @@ variable "datacommons_services_config" {
     allow_unauthenticated_access    = bool
     website_disable_google_maps_api = bool
     resolve_with_spanner_embeddings = bool
+    v2_resolve_indicators_target    = optional(string, "")
   })
 }
 

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -37,21 +37,21 @@ variable "spanner_config" {
 
 variable "datacommons_services_config" {
   type = object({
-    enable                            = bool
-    image                             = optional(string)
-    name                              = string
-    min_instances                     = number
-    max_instances                     = number
-    cpu                               = string
-    memory                            = string
-    google_analytics_tag              = string
-    enable_mcp                        = bool
-    search_scope                      = string
-    instructions_path                 = string
-    allow_unauthenticated_access      = bool
-    website_disable_google_maps_api   = bool
-    resolve_with_spanner_embeddings   = bool
-    website_resolve_indicators_target = optional(string, "")
+    enable                          = bool
+    image                           = optional(string)
+    name                            = string
+    min_instances                   = number
+    max_instances                   = number
+    cpu                             = string
+    memory                          = string
+    google_analytics_tag            = string
+    enable_mcp                      = bool
+    search_scope                    = string
+    instructions_path               = string
+    allow_unauthenticated_access    = bool
+    website_disable_google_maps_api = bool
+    resolve_with_spanner_embeddings = bool
+    website_search_scope            = optional(string, "")
   })
 }
 

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -37,21 +37,21 @@ variable "spanner_config" {
 
 variable "datacommons_services_config" {
   type = object({
-    enable                               = bool
-    image                                = optional(string)
-    name                                 = string
-    min_instances                        = number
-    max_instances                        = number
-    cpu                                  = string
-    memory                               = string
-    google_analytics_tag                 = string
-    enable_mcp                           = bool
-    search_scope                         = string
-    instructions_path                    = string
-    allow_unauthenticated_access         = bool
-    website_disable_google_maps_api      = bool
-    resolve_with_spanner_embeddings      = bool
-    website_v2_resolve_indicators_target = optional(string, "")
+    enable                            = bool
+    image                             = optional(string)
+    name                              = string
+    min_instances                     = number
+    max_instances                     = number
+    cpu                               = string
+    memory                            = string
+    google_analytics_tag              = string
+    enable_mcp                        = bool
+    search_scope                      = string
+    instructions_path                 = string
+    allow_unauthenticated_access      = bool
+    website_disable_google_maps_api   = bool
+    resolve_with_spanner_embeddings   = bool
+    website_resolve_indicators_target = optional(string, "")
   })
 }
 

--- a/infra/dcp/terraform.tfvars.template
+++ b/infra/dcp/terraform.tfvars.template
@@ -63,7 +63,7 @@ datacommons_services_allow_unauthenticated_access = false
 # datacommons_services_google_analytics_tag_id = "your-analytics-tag-id"
 
 # Target scope for indicator v2/resolve API calls made by the website service (optional, e.g. "sdmx").
-# datacommons_services_v2_resolve_indicators_target = ""
+# datacommons_services_website_v2_resolve_indicators_target = ""
 
 # =============================================================================
 # Ingestion - Preprocessing Job

--- a/infra/dcp/terraform.tfvars.template
+++ b/infra/dcp/terraform.tfvars.template
@@ -63,7 +63,7 @@ datacommons_services_allow_unauthenticated_access = false
 # datacommons_services_google_analytics_tag_id = "your-analytics-tag-id"
 
 # Target scope for indicator v2/resolve API calls made by the website service (optional, e.g. "sdmx").
-# datacommons_services_website_v2_resolve_indicators_target = ""
+# datacommons_services_website_resolve_indicators_target = ""
 
 # =============================================================================
 # Ingestion - Preprocessing Job

--- a/infra/dcp/terraform.tfvars.template
+++ b/infra/dcp/terraform.tfvars.template
@@ -62,6 +62,9 @@ datacommons_services_allow_unauthenticated_access = false
 # Track traffic and user interactions with your site using Google Analytics.
 # datacommons_services_google_analytics_tag_id = "your-analytics-tag-id"
 
+# Target scope for indicator v2/resolve API calls made by the website service (optional, e.g. "sdmx").
+# datacommons_services_v2_resolve_indicators_target = ""
+
 # =============================================================================
 # Ingestion - Preprocessing Job
 # =============================================================================

--- a/infra/dcp/terraform.tfvars.template
+++ b/infra/dcp/terraform.tfvars.template
@@ -62,8 +62,9 @@ datacommons_services_allow_unauthenticated_access = false
 # Track traffic and user interactions with your site using Google Analytics.
 # datacommons_services_google_analytics_tag_id = "your-analytics-tag-id"
 
-# Target scope for indicator v2/resolve API calls made by the website service (optional, e.g. "sdmx").
-# datacommons_services_website_resolve_indicators_target = ""
+# Controls the scope for indicator resolution on the website Explore page (e.g., restricting queries to custom variables).
+# Valid values are 'base_only', 'custom_only', 'base_and_custom'. Default is base_and_custom.
+# datacommons_services_website_search_scope = ""
 
 # =============================================================================
 # Ingestion - Preprocessing Job

--- a/infra/dcp/terraform.tfvars.template
+++ b/infra/dcp/terraform.tfvars.template
@@ -62,10 +62,6 @@ datacommons_services_allow_unauthenticated_access = false
 # Track traffic and user interactions with your site using Google Analytics.
 # datacommons_services_google_analytics_tag_id = "your-analytics-tag-id"
 
-# Controls the scope for indicator resolution on the website Explore page (e.g., restricting queries to custom variables).
-# Valid values are 'base_only', 'custom_only', 'base_and_custom'. Default is base_and_custom.
-# datacommons_services_website_search_scope = ""
-
 # =============================================================================
 # Ingestion - Preprocessing Job
 # =============================================================================

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -317,7 +317,7 @@ variable "datacommons_services_resolve_with_spanner_embeddings" {
 }
 
 variable "datacommons_services_website_search_scope" {
-  description = "Controls the scope for indicator resolution on the website Explore page (e.g., restricting queries to custom variables). Valid values are 'base_only', 'custom_only', 'base_and_custom'. Default is base_and_custom"
+  description = "Controls the scope for indicator resolution on the website Explore page (e.g., restricting queries to custom variables). Valid values are 'base_only', 'custom_only', 'base_and_custom'."
   type        = string
   default     = "base_and_custom"
 }

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -316,7 +316,7 @@ variable "datacommons_services_resolve_with_spanner_embeddings" {
   default     = true
 }
 
-variable "datacommons_services_v2_resolve_indicators_target" {
+variable "datacommons_services_website_v2_resolve_indicators_target" {
   description = "Target parameter for v2/resolve API calls made by website service when resolver=indicator."
   type        = string
   default     = ""

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -319,7 +319,7 @@ variable "datacommons_services_resolve_with_spanner_embeddings" {
 variable "datacommons_services_website_search_scope" {
   description = "Controls the scope for indicator resolution on the website Explore page (e.g., restricting queries to custom variables). Valid values are 'base_only', 'custom_only', 'base_and_custom'. Default is base_and_custom"
   type        = string
-  default     = ""
+  default     = "base_and_custom"
 }
 
 # =============================================================================

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -316,8 +316,8 @@ variable "datacommons_services_resolve_with_spanner_embeddings" {
   default     = true
 }
 
-variable "datacommons_services_website_resolve_indicators_target" {
-  description = "Target parameter for v2/resolve API calls made by website service when resolver=indicator."
+variable "datacommons_services_website_search_scope" {
+  description = "Controls the scope for indicator resolution on the website Explore page (e.g., restricting queries to custom variables). Valid values are 'base_only', 'custom_only', 'base_and_custom'. Default is base_and_custom"
   type        = string
   default     = ""
 }

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -316,6 +316,12 @@ variable "datacommons_services_resolve_with_spanner_embeddings" {
   default     = true
 }
 
+variable "datacommons_services_v2_resolve_indicators_target" {
+  description = "Target parameter for v2/resolve API calls made by website service when resolver=indicator."
+  type        = string
+  default     = ""
+}
+
 # =============================================================================
 # Ingestion - Preprocessing Job
 # =============================================================================

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -316,7 +316,7 @@ variable "datacommons_services_resolve_with_spanner_embeddings" {
   default     = true
 }
 
-variable "datacommons_services_website_v2_resolve_indicators_target" {
+variable "datacommons_services_website_resolve_indicators_target" {
   description = "Target parameter for v2/resolve API calls made by website service when resolver=indicator."
   type        = string
   default     = ""


### PR DESCRIPTION
### Description
Exposes `datacommons_services_website_search_scope` in the DCP Terraform module hierarchy and sets the `V2_RESOLVE_INDICATORS_TARGET` environment variable on the Cloud Run website service container.

### Changes
- **[infra/dcp/variables.tf](file:///Users/calinc/datcom-datacommons/infra/dcp/variables.tf)**: Added top-level `datacommons_services_website_search_scope` variable definition with default `"base_and_custom"` and description listing valid values (`base_only`, `custom_only`, `base_and_custom`).
- **[infra/dcp/main.tf](file:///Users/calinc/datcom-datacommons/infra/dcp/main.tf)** & **[infra/dcp/modules/stack/](file:///Users/calinc/datcom-datacommons/infra/dcp/modules/stack/)**: Passed variable through `datacommons_services_config` local into `module "datacommons_services"`.
- **[infra/dcp/modules/datacommons_services/main.tf](file:///Users/calinc/datcom-datacommons/infra/dcp/modules/datacommons_services/main.tf)**: Set `V2_RESOLVE_INDICATORS_TARGET` environment variable on the `dc_web_service` Cloud Run container.