### PR TITLE
[Redis] VPC Connector name was too long

### DIFF
--- a/infra/dcp/modules/redis/main.tf
+++ b/infra/dcp/modules/redis/main.tf
@@ -1,6 +1,8 @@
 locals {
   name_prefix         = var.namespace != "" ? "${var.namespace}-" : ""
   display_name_prefix = var.namespace != "" ? "(${var.namespace}) " : ""
+  # Trimmed because the connector name is capped to 25 chars.
+  vpc_name_prefix     = var.namespace != "" ? "${trimsuffix(substr(var.namespace, 0, 13), "-")}-" : ""
 }
 
 resource "google_redis_instance" "redis_instance" {
@@ -20,7 +22,7 @@ resource "google_redis_instance" "redis_instance" {
 
 resource "google_vpc_access_connector" "connector" {
   count = var.enable_connector ? 1 : 0
-  name  = "${local.name_prefix}dc-vpc-conn"
+  name  = "${local.vpc_name_prefix}dc-vpc-conn"
 
   region        = var.region
   network       = var.vpc_network_id

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -118,13 +118,13 @@ variable "redis_tier" {
 variable "redis_location_id" {
   description = "The primary zone where the Redis instance will be located"
   type        = string
-  default     = "us-central1-a"
+  default     = null
 }
 
 variable "redis_alternative_location_id" {
   description = "The alternative zone for the failover Redis instance (required for STANDARD_HA tier)"
   type        = string
-  default     = "us-central1-b"
+  default     = null
 }
 
 variable "redis_replica_count" {


### PR DESCRIPTION
These were the issues that some teammembers experiecned during the bug bash. The VPC conenctor name is limited to 25 chars. We append "dc-vpc-conn", so we now trim to the first 13 chars of the instance name.

also removes the default zones and alternate zone for redis. Tested successfully.