### PR TITLE
Expose Data Commons serving service account email

### DIFF
--- a/infra/dcp/README.md
+++ b/infra/dcp/README.md
@@ -92,6 +92,7 @@ Once configured, execute standard Terraform commands to provision resources:
 Upon successful apply, Terraform displays key endpoints and resource names:
 *   `platform_service_url`: Cloud Run service URL for the platform service.
 *   `datacommons_service_url`: Cloud Run service URL for the Data Commons service.
+*   `datacommons_service_service_account_email`: Email of the service account used by the Data Commons serving service.
 *   `ingestion_workflow_name`: Name of the Cloud Workflows ingestion orchestrator.
 *   `ingestion_service_uri`: URI of the ingestion support Cloud Run service.
 *   `ingestion_prep_job_name`: Name of the data ingestion pre-processing job.

--- a/infra/dcp/modules/stack/outputs.tf
+++ b/infra/dcp/modules/stack/outputs.tf
@@ -17,7 +17,8 @@ output "datacommons_service_name" {
 }
 
 output "datacommons_service_service_account_email" {
-  value = length(module.datacommons_services) > 0 ? module.datacommons_services[0].service_account_email : null
+  description = "Email of the service account used by the Data Commons serving service"
+  value       = length(module.datacommons_services) > 0 ? module.datacommons_services[0].service_account_email : null
 }
 
 output "ingestion_workflow_id" {

--- a/infra/dcp/modules/stack/outputs.tf
+++ b/infra/dcp/modules/stack/outputs.tf
@@ -16,6 +16,10 @@ output "datacommons_service_name" {
   value = length(module.datacommons_services) > 0 ? module.datacommons_services[0].service_name : null
 }
 
+output "datacommons_service_service_account_email" {
+  value = length(module.datacommons_services) > 0 ? module.datacommons_services[0].service_account_email : null
+}
+
 output "ingestion_workflow_id" {
   description = "ID of the ingestion Cloud Workflow"
   value       = module.ingestion_workflow.workflow_id

--- a/infra/dcp/outputs.tf
+++ b/infra/dcp/outputs.tf
@@ -15,6 +15,11 @@ output "datacommons_service_name" {
   value = module.stack.datacommons_service_name
 }
 
+output "datacommons_service_service_account_email" {
+  description = "Email of the service account used by the Data Commons serving service"
+  value       = module.stack.datacommons_service_service_account_email
+}
+
 output "ingestion_workflow_id" {
   description = "ID of the ingestion Cloud Workflows orchestrator"
   value       = module.stack.ingestion_workflow_id


### PR DESCRIPTION
Expose the email of the Data Commons serving SA at the module root so that consumers can reference it when provisioning other infrastructure.