### PR TITLE
[DCP Ingestion] Allow dataflow to scale it s workers based on Terraform Variables

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -147,10 +147,13 @@ locals {
     workflow_lock_acquisition_timeout = var.ingestion_workflow_lock_acquisition_timeout
     helper_service_image              = coalesce(var.ingestion_helper_service_image, "gcr.io/datcom-ci/datacommons-ingestion-helper:${var.dcp_version}")
 
-    # Dataflow Network Configuration
+    # Dataflow Network & Scaling Configuration
     dataflow_ip_configuration  = var.ingestion_dataflow_ip_configuration
     dataflow_subnetwork        = var.ingestion_dataflow_subnetwork
     dataflow_template_gcs_path = coalesce(var.ingestion_dataflow_template_gcs_path, "gs://datcom-templates/templates/flex/ingestion-${local.df_template_version}.json")
+    dataflow_max_workers         = var.ingestion_dataflow_max_workers
+    dataflow_num_workers         = var.ingestion_dataflow_num_workers
+    dataflow_worker_machine_type = var.ingestion_dataflow_worker_machine_type
   }
 }
 

--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -34,6 +34,9 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
     enable_redis_cache_clearing    = var.enable_redis_cache_clearing
     preprocessing_job_name         = var.preprocessing_job_name
     postprocessing_job_name        = var.postprocessing_job_name
+    dataflow_max_workers         = var.dataflow_max_workers
+    dataflow_num_workers         = var.dataflow_num_workers
+    dataflow_worker_machine_type = var.dataflow_worker_machine_type
   })
 }
 

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -128,7 +128,6 @@ variable "dataflow_template_gcs_path" {
 variable "dataflow_max_workers" {
   type        = number
   description = "Maximum number of Dataflow worker VMs"
-  default     = 20
   nullable    = false
 
   validation {
@@ -140,7 +139,6 @@ variable "dataflow_max_workers" {
 variable "dataflow_num_workers" {
   type        = number
   description = "Initial number of Dataflow worker VMs"
-  default     = 4
   nullable    = false
 
   validation {
@@ -152,7 +150,6 @@ variable "dataflow_num_workers" {
 variable "dataflow_worker_machine_type" {
   type        = string
   description = "Machine type for Dataflow worker VMs"
-  default     = "n2-standard-4"
   nullable    = false
 
   validation {

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -129,17 +129,42 @@ variable "dataflow_max_workers" {
   type        = number
   description = "Maximum number of Dataflow worker VMs"
   default     = 20
+  nullable    = false
+
+  validation {
+    condition     = var.dataflow_max_workers > 0
+    error_message = "The dataflow_max_workers must be a positive integer."
+  }
 }
 
 variable "dataflow_num_workers" {
   type        = number
   description = "Initial number of Dataflow worker VMs"
   default     = 4
+  nullable    = false
+
+  validation {
+    condition     = var.dataflow_num_workers > 0
+    error_message = "The dataflow_num_workers must be a positive integer."
+  }
 }
 
 variable "dataflow_worker_machine_type" {
   type        = string
   description = "Machine type for Dataflow worker VMs"
   default     = "n2-standard-4"
+  nullable    = false
+
+  validation {
+    condition     = length(var.dataflow_worker_machine_type) > 0
+    error_message = "The dataflow_worker_machine_type must not be empty."
+  }
+}
+
+check "dataflow_workers_limits" {
+  assert {
+    condition     = var.dataflow_max_workers >= var.dataflow_num_workers
+    error_message = "The dataflow_max_workers must be greater than or equal to dataflow_num_workers."
+  }
 }
 

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -125,3 +125,21 @@ variable "dataflow_template_gcs_path" {
   }
 }
 
+variable "dataflow_max_workers" {
+  type        = number
+  description = "Maximum number of Dataflow worker VMs"
+  default     = 20
+}
+
+variable "dataflow_num_workers" {
+  type        = number
+  description = "Initial number of Dataflow worker VMs"
+  default     = 4
+}
+
+variable "dataflow_worker_machine_type" {
+  type        = string
+  description = "Machine type for Dataflow worker VMs"
+  default     = "n2-standard-4"
+}
+

--- a/infra/dcp/modules/ingestion/workflow/workflow.yaml
+++ b/infra/dcp/modules/ingestion/workflow/workflow.yaml
@@ -420,6 +420,9 @@ launch_and_poll_dataflow:
               serviceAccountEmail: '${dataflow_service_account_email}'
               tempLocation: $${temp_location}
               stagingLocation: $${temp_location}
+              maxWorkers: ${dataflow_max_workers}
+              numWorkers: ${dataflow_num_workers}
+              machineType: '${dataflow_worker_machine_type}'
 %{ if dataflow_ip_configuration != "WORKER_IP_UNSPECIFIED" }
     - inject_ip:
         assign:

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -223,6 +223,9 @@ module "ingestion_workflow" {
   dataflow_ip_configuration      = var.ingestion_config.dataflow_ip_configuration
   dataflow_subnetwork            = var.ingestion_config.dataflow_subnetwork
   dataflow_template_gcs_path     = var.ingestion_config.dataflow_template_gcs_path
+  dataflow_max_workers         = var.ingestion_config.dataflow_max_workers
+  dataflow_num_workers         = var.ingestion_config.dataflow_num_workers
+  dataflow_worker_machine_type = var.ingestion_config.dataflow_worker_machine_type
   preprocessing_job_name         = var.ingestion_config.enable_ingestion ? module.ingestion_preprocessing_job[0].job_name : ""
   postprocessing_job_name        = var.ingestion_config.enable_ingestion ? module.ingestion_postprocessing_job[0].job_name : ""
 

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -112,5 +112,8 @@ variable "ingestion_config" {
     dataflow_ip_configuration  = optional(string, "WORKER_IP_UNSPECIFIED")
     dataflow_subnetwork        = optional(string, "")
     dataflow_template_gcs_path = optional(string)
+    dataflow_max_workers         = optional(number, 20)
+    dataflow_num_workers         = optional(number, 4)
+    dataflow_worker_machine_type = optional(string, "n2-standard-4")
   })
 }

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -112,8 +112,8 @@ variable "ingestion_config" {
     dataflow_ip_configuration  = optional(string, "WORKER_IP_UNSPECIFIED")
     dataflow_subnetwork        = optional(string, "")
     dataflow_template_gcs_path = optional(string)
-    dataflow_max_workers         = optional(number, 20)
-    dataflow_num_workers         = optional(number, 4)
-    dataflow_worker_machine_type = optional(string, "n2-standard-4")
+    dataflow_max_workers         = optional(number)
+    dataflow_num_workers         = optional(number)
+    dataflow_worker_machine_type = optional(string)
   })
 }

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -112,8 +112,8 @@ variable "ingestion_config" {
     dataflow_ip_configuration  = optional(string, "WORKER_IP_UNSPECIFIED")
     dataflow_subnetwork        = optional(string, "")
     dataflow_template_gcs_path = optional(string)
-    dataflow_max_workers         = optional(number)
-    dataflow_num_workers         = optional(number)
-    dataflow_worker_machine_type = optional(string)
+    dataflow_max_workers         = optional(number, 20)
+    dataflow_num_workers         = optional(number, 4)
+    dataflow_worker_machine_type = optional(string, "n2-standard-4")
   })
 }

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -454,3 +454,21 @@ variable "ingestion_dataflow_template_gcs_path" {
   default     = null
 }
 
+variable "ingestion_dataflow_max_workers" {
+  description = "Maximum number of Dataflow worker VMs for autoscaling during ingestion."
+  type        = number
+  default     = 20
+}
+
+variable "ingestion_dataflow_num_workers" {
+  description = "Initial number of Dataflow worker VMs to launch during ingestion."
+  type        = number
+  default     = 4
+}
+
+variable "ingestion_dataflow_worker_machine_type" {
+  description = "GCP Compute Engine machine type for Dataflow worker VMs."
+  type        = string
+  default     = "n2-standard-4"
+}
+

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -457,18 +457,35 @@ variable "ingestion_dataflow_template_gcs_path" {
 variable "ingestion_dataflow_max_workers" {
   description = "Maximum number of Dataflow worker VMs for autoscaling during ingestion."
   type        = number
-  default     = 20
+  default     = null
+
+  validation {
+    condition     = var.ingestion_dataflow_max_workers == null || var.ingestion_dataflow_max_workers > 0
+    error_message = "The ingestion_dataflow_max_workers must be a positive integer."
+  }
 }
 
 variable "ingestion_dataflow_num_workers" {
   description = "Initial number of Dataflow worker VMs to launch during ingestion."
   type        = number
-  default     = 4
+  default     = null
+
+  validation {
+    condition     = var.ingestion_dataflow_num_workers == null || var.ingestion_dataflow_num_workers > 0
+    error_message = "The ingestion_dataflow_num_workers must be a positive integer."
+  }
 }
 
 variable "ingestion_dataflow_worker_machine_type" {
   description = "GCP Compute Engine machine type for Dataflow worker VMs."
   type        = string
-  default     = "n2-standard-4"
+  default     = null
+}
+
+check "ingestion_dataflow_workers_limits" {
+  assert {
+    condition     = var.ingestion_dataflow_max_workers == null || var.ingestion_dataflow_num_workers == null || var.ingestion_dataflow_max_workers >= var.ingestion_dataflow_num_workers
+    error_message = "The ingestion_dataflow_max_workers must be greater than or equal to ingestion_dataflow_num_workers."
+  }
 }
 

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -457,10 +457,10 @@ variable "ingestion_dataflow_template_gcs_path" {
 variable "ingestion_dataflow_max_workers" {
   description = "Maximum number of Dataflow worker VMs for autoscaling during ingestion."
   type        = number
-  default     = null
+  default     = 20
 
   validation {
-    condition     = var.ingestion_dataflow_max_workers == null || var.ingestion_dataflow_max_workers > 0
+    condition     = var.ingestion_dataflow_max_workers > 0
     error_message = "The ingestion_dataflow_max_workers must be a positive integer."
   }
 }
@@ -468,10 +468,10 @@ variable "ingestion_dataflow_max_workers" {
 variable "ingestion_dataflow_num_workers" {
   description = "Initial number of Dataflow worker VMs to launch during ingestion."
   type        = number
-  default     = null
+  default     = 4
 
   validation {
-    condition     = var.ingestion_dataflow_num_workers == null || var.ingestion_dataflow_num_workers > 0
+    condition     = var.ingestion_dataflow_num_workers > 0
     error_message = "The ingestion_dataflow_num_workers must be a positive integer."
   }
 }
@@ -479,12 +479,17 @@ variable "ingestion_dataflow_num_workers" {
 variable "ingestion_dataflow_worker_machine_type" {
   description = "GCP Compute Engine machine type for Dataflow worker VMs."
   type        = string
-  default     = null
+  default     = "n2-standard-4"
+
+  validation {
+    condition     = length(var.ingestion_dataflow_worker_machine_type) > 0
+    error_message = "The ingestion_dataflow_worker_machine_type must not be empty."
+  }
 }
 
 check "ingestion_dataflow_workers_limits" {
   assert {
-    condition     = var.ingestion_dataflow_max_workers == null || var.ingestion_dataflow_num_workers == null || var.ingestion_dataflow_max_workers >= var.ingestion_dataflow_num_workers
+    condition     = var.ingestion_dataflow_max_workers >= var.ingestion_dataflow_num_workers
     error_message = "The ingestion_dataflow_max_workers must be greater than or equal to ingestion_dataflow_num_workers."
   }
 }


### PR DESCRIPTION
Allow DCP owners to set their own dataflow laucnh params from terraform.

Note that for now we will just require them to control this at the terraform level. Longer term, I would rather this be contorllable at the import level. Smaller imports can use cheaper machines and fewer workers. This unlocks immediate control.

Loaded 22M rows with 13 minutes of dataflow processing on pretty reasonable values:

spanner_processing_units = 1000
ingestion_dataflow_num_workers         = 10         
ingestion_dataflow_max_workers         = 30         
ingestion_dataflow_worker_machine_type = "n2-standard-4"