### PR TITLE
[terraform] re-enable datacommons-services restart post-ingestion

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -148,9 +148,9 @@ locals {
     helper_service_image              = coalesce(var.ingestion_helper_service_image, "gcr.io/datcom-ci/datacommons-ingestion-helper:${var.dcp_version}")
 
     # Dataflow Network & Scaling Configuration
-    dataflow_ip_configuration  = var.ingestion_dataflow_ip_configuration
-    dataflow_subnetwork        = var.ingestion_dataflow_subnetwork
-    dataflow_template_gcs_path = coalesce(var.ingestion_dataflow_template_gcs_path, "gs://datcom-templates/templates/flex/ingestion-${local.df_template_version}.json")
+    dataflow_ip_configuration    = var.ingestion_dataflow_ip_configuration
+    dataflow_subnetwork          = var.ingestion_dataflow_subnetwork
+    dataflow_template_gcs_path   = coalesce(var.ingestion_dataflow_template_gcs_path, "gs://datcom-templates/templates/flex/ingestion-${local.df_template_version}.json")
     dataflow_max_workers         = var.ingestion_dataflow_max_workers
     dataflow_num_workers         = var.ingestion_dataflow_num_workers
     dataflow_worker_machine_type = var.ingestion_dataflow_worker_machine_type

--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -20,6 +20,7 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
 
   source_contents = templatefile("${path.module}/workflow.yaml", {
     project_id                          = var.project_id
+    region                              = var.region
     ingestion_helper_url                = var.ingestion_helper_url
     lock_acquisition_timeout            = var.lock_acquisition_timeout
     enable_embeddings_generation        = var.enable_embeddings_generation

--- a/infra/dcp/modules/ingestion/workflow/main.tf
+++ b/infra/dcp/modules/ingestion/workflow/main.tf
@@ -1,6 +1,6 @@
 locals {
-  name_prefix               = var.instance_name != "" ? "${var.instance_name}-" : ""
-  should_run_postprocessing = var.enable_bigquery_postprocessing || var.enable_embeddings_generation
+  name_prefix                = var.instance_name != "" ? "${var.instance_name}-" : ""
+  should_run_postprocessing  = var.enable_bigquery_postprocessing || var.enable_embeddings_generation
   clean_instance_name_prefix = var.instance_name != "" ? "${replace(lower(var.instance_name), "_", "-")}-" : ""
 }
 
@@ -19,24 +19,26 @@ resource "google_workflows_workflow" "ingestion_orchestrator" {
   deletion_protection = var.stateless_deletion_protection
 
   source_contents = templatefile("${path.module}/workflow.yaml", {
-    project_id                     = var.project_id
-    ingestion_helper_url           = var.ingestion_helper_url
-    lock_acquisition_timeout       = var.lock_acquisition_timeout
-    enable_embeddings_generation   = var.enable_embeddings_generation
-    enable_bigquery_postprocessing = var.enable_bigquery_postprocessing
-    ingestion_artifacts_path       = var.ingestion_artifacts_path
-    dataflow_template_gcs_path     = var.dataflow_template_gcs_path
-    dataflow_service_account_email = var.dataflow_service_account_email
-    dataflow_ip_configuration      = var.dataflow_ip_configuration
-    dataflow_subnetwork            = var.dataflow_subnetwork
-    embeddings_timeout             = var.embeddings_timeout
-    clean_instance_name_prefix     = local.clean_instance_name_prefix
-    enable_redis_cache_clearing    = var.enable_redis_cache_clearing
-    preprocessing_job_name         = var.preprocessing_job_name
-    postprocessing_job_name        = var.postprocessing_job_name
-    dataflow_max_workers         = var.dataflow_max_workers
-    dataflow_num_workers         = var.dataflow_num_workers
-    dataflow_worker_machine_type = var.dataflow_worker_machine_type
+    project_id                          = var.project_id
+    ingestion_helper_url                = var.ingestion_helper_url
+    lock_acquisition_timeout            = var.lock_acquisition_timeout
+    enable_embeddings_generation        = var.enable_embeddings_generation
+    enable_bigquery_postprocessing      = var.enable_bigquery_postprocessing
+    ingestion_artifacts_path            = var.ingestion_artifacts_path
+    dataflow_template_gcs_path          = var.dataflow_template_gcs_path
+    dataflow_service_account_email      = var.dataflow_service_account_email
+    dataflow_ip_configuration           = var.dataflow_ip_configuration
+    dataflow_subnetwork                 = var.dataflow_subnetwork
+    embeddings_timeout                  = var.embeddings_timeout
+    clean_instance_name_prefix          = local.clean_instance_name_prefix
+    enable_redis_cache_clearing         = var.enable_redis_cache_clearing
+    preprocessing_job_name              = var.preprocessing_job_name
+    postprocessing_job_name             = var.postprocessing_job_name
+    dataflow_max_workers                = var.dataflow_max_workers
+    dataflow_num_workers                = var.dataflow_num_workers
+    dataflow_worker_machine_type        = var.dataflow_worker_machine_type
+    enable_datacommons_services_restart = var.enable_datacommons_services_restart
+    datacommons_services_name           = var.datacommons_services_name
   })
 }
 

--- a/infra/dcp/modules/ingestion/workflow/variables.tf
+++ b/infra/dcp/modules/ingestion/workflow/variables.tf
@@ -59,6 +59,19 @@ variable "enable_redis_cache_clearing" {
   default     = false
 }
 
+variable "enable_datacommons_services_restart" {
+  type        = bool
+  description = "Flag to indicate if datacommons_services should be restarted after ingestion completes"
+  default     = true
+}
+
+variable "datacommons_services_name" {
+  type        = string
+  description = "Name of the datacommons_services Cloud Run service to restart after ingestion"
+  default     = ""
+}
+
+
 variable "preprocessing_job_name" {
   type        = string
   description = "Name of the ingestion preprocessing Cloud Run job"

--- a/infra/dcp/modules/ingestion/workflow/workflow.yaml
+++ b/infra/dcp/modules/ingestion/workflow/workflow.yaml
@@ -319,7 +319,7 @@ main:
     - restart_service:
         call: googleapis.run.v2.projects.locations.services.patch
         args:
-          name: '$${"projects/" + project_id + "/locations/${region}/services/" + datacommons_services_name}'
+          name: '$${"projects/" + project_id + "/locations/${region}/services/${datacommons_services_name}"}'
           updateMask: "template.labels"
           body:
             template:

--- a/infra/dcp/modules/ingestion/workflow/workflow.yaml
+++ b/infra/dcp/modules/ingestion/workflow/workflow.yaml
@@ -315,8 +315,21 @@ main:
             type: OIDC
 %{ endif }
 
+%{ if enable_datacommons_services_restart && datacommons_services_name != "" }
+    - restart_service:
+        call: googleapis.run.v2.projects.locations.services.patch
+        args:
+          name: '$${"projects/" + project_id + "/locations/" + region + "/services/" + datacommons_services_name}'
+          updateMask: "template.labels"
+          body:
+            template:
+              labels:
+                restarted-at: '$${string(int(sys.now()))}'
+%{ endif }
+
     - return_result:
         return: '$${launch_result}'
+
 
 
 # --- Subworkflows ---

--- a/infra/dcp/modules/ingestion/workflow/workflow.yaml
+++ b/infra/dcp/modules/ingestion/workflow/workflow.yaml
@@ -319,7 +319,7 @@ main:
     - restart_service:
         call: googleapis.run.v2.projects.locations.services.patch
         args:
-          name: 'projects/$${project_id}/locations/${region}/services/${datacommons_services_name}'
+          name: 'projects/${project_id}/locations/${region}/services/${datacommons_services_name}'
           updateMask: "template.labels"
           body:
             template:

--- a/infra/dcp/modules/ingestion/workflow/workflow.yaml
+++ b/infra/dcp/modules/ingestion/workflow/workflow.yaml
@@ -319,7 +319,7 @@ main:
     - restart_service:
         call: googleapis.run.v2.projects.locations.services.patch
         args:
-          name: '$${"projects/" + project_id + "/locations/" + region + "/services/" + datacommons_services_name}'
+          name: '$${"projects/" + project_id + "/locations/${region}/services/" + datacommons_services_name}'
           updateMask: "template.labels"
           body:
             template:

--- a/infra/dcp/modules/ingestion/workflow/workflow.yaml
+++ b/infra/dcp/modules/ingestion/workflow/workflow.yaml
@@ -319,7 +319,7 @@ main:
     - restart_service:
         call: googleapis.run.v2.projects.locations.services.patch
         args:
-          name: '$${"projects/" + project_id + "/locations/${region}/services/${datacommons_services_name}"}'
+          name: 'projects/$${project_id}/locations/${region}/services/${datacommons_services_name}'
           updateMask: "template.labels"
           body:
             template:

--- a/infra/dcp/modules/redis/main.tf
+++ b/infra/dcp/modules/redis/main.tf
@@ -2,7 +2,7 @@ locals {
   name_prefix         = var.instance_name != "" ? "${var.instance_name}-" : ""
   display_name_prefix = var.instance_name != "" ? "(${var.instance_name}) " : ""
   # Trimmed because the connector name is capped to 25 chars.
-  vpc_name_prefix     = var.instance_name != "" ? "${trimsuffix(substr(var.instance_name, 0, 13), "-")}-" : ""
+  vpc_name_prefix = var.instance_name != "" ? "${trimsuffix(substr(var.instance_name, 0, 13), "-")}-" : ""
 }
 
 resource "google_redis_instance" "redis_instance" {

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -106,7 +106,7 @@ module "storage" {
   stateful_deletion_protection = var.global.stateful_deletion_protection
 
   # Shared vars
-  project_id = var.global.project_id
+  project_id    = var.global.project_id
   instance_name = var.global.instance_name
 }
 
@@ -207,27 +207,29 @@ module "ingestion_helper_service" {
 module "ingestion_workflow" {
   source = "../ingestion/workflow"
 
-  deploy                         = var.ingestion_config.enable_ingestion
-  instance_name                  = var.global.instance_name
-  region                         = var.global.region
-  stateless_deletion_protection  = var.global.stateless_deletion_protection
-  project_id                     = var.global.project_id
-  lock_acquisition_timeout       = var.ingestion_config.workflow_lock_acquisition_timeout
-  ingestion_helper_url           = module.ingestion_helper_service.ingestion_helper_url
-  dataflow_service_account_email = module.ingestion_dataflow.service_account_email
-  enable_bigquery_postprocessing = var.ingestion_config.workflow_enable_bigquery_postprocessing
-  enable_embeddings_generation   = var.spanner_config.enable_embeddings_generation
-  ingestion_helper_service_name  = "${var.global.instance_name != "" ? "${var.global.instance_name}-" : ""}dc-ingestion-helper"
-  enable_redis_cache_clearing    = var.redis_config.enable
-  ingestion_artifacts_path       = "${var.ingestion_config.ingestion_artifacts_path}/metadata"
-  dataflow_ip_configuration      = var.ingestion_config.dataflow_ip_configuration
-  dataflow_subnetwork            = var.ingestion_config.dataflow_subnetwork
-  dataflow_template_gcs_path     = var.ingestion_config.dataflow_template_gcs_path
-  dataflow_max_workers         = var.ingestion_config.dataflow_max_workers
-  dataflow_num_workers         = var.ingestion_config.dataflow_num_workers
-  dataflow_worker_machine_type = var.ingestion_config.dataflow_worker_machine_type
-  preprocessing_job_name         = var.ingestion_config.enable_ingestion ? module.ingestion_preprocessing_job[0].job_name : ""
-  postprocessing_job_name        = var.ingestion_config.enable_ingestion ? module.ingestion_postprocessing_job[0].job_name : ""
+  deploy                              = var.ingestion_config.enable_ingestion
+  instance_name                       = var.global.instance_name
+  region                              = var.global.region
+  stateless_deletion_protection       = var.global.stateless_deletion_protection
+  project_id                          = var.global.project_id
+  lock_acquisition_timeout            = var.ingestion_config.workflow_lock_acquisition_timeout
+  ingestion_helper_url                = module.ingestion_helper_service.ingestion_helper_url
+  dataflow_service_account_email      = module.ingestion_dataflow.service_account_email
+  enable_bigquery_postprocessing      = var.ingestion_config.workflow_enable_bigquery_postprocessing
+  enable_embeddings_generation        = var.spanner_config.enable_embeddings_generation
+  ingestion_helper_service_name       = "${var.global.instance_name != "" ? "${var.global.instance_name}-" : ""}dc-ingestion-helper"
+  enable_redis_cache_clearing         = var.redis_config.enable
+  ingestion_artifacts_path            = "${var.ingestion_config.ingestion_artifacts_path}/metadata"
+  dataflow_ip_configuration           = var.ingestion_config.dataflow_ip_configuration
+  dataflow_subnetwork                 = var.ingestion_config.dataflow_subnetwork
+  dataflow_template_gcs_path          = var.ingestion_config.dataflow_template_gcs_path
+  dataflow_max_workers                = var.ingestion_config.dataflow_max_workers
+  dataflow_num_workers                = var.ingestion_config.dataflow_num_workers
+  dataflow_worker_machine_type        = var.ingestion_config.dataflow_worker_machine_type
+  preprocessing_job_name              = var.ingestion_config.enable_ingestion ? module.ingestion_preprocessing_job[0].job_name : ""
+  postprocessing_job_name             = var.ingestion_config.enable_ingestion ? module.ingestion_postprocessing_job[0].job_name : ""
+  enable_datacommons_services_restart = var.datacommons_services_config.enable
+  datacommons_services_name           = "${var.global.instance_name != "" ? "${var.global.instance_name}-" : ""}dc-datacommons-service"
 
   depends_on = [module.ingestion_helper_service]
 }
@@ -414,4 +416,19 @@ resource "google_project_iam_member" "workflow_run_viewer" {
   project = var.global.project_id
   role    = "roles/run.viewer"
   member  = "serviceAccount:${module.ingestion_workflow.service_account_email}"
+}
+
+resource "google_cloud_run_v2_service_iam_member" "workflow_serving_developer" {
+  count    = var.ingestion_config.enable_ingestion && var.datacommons_services_config.enable ? 1 : 0
+  location = var.global.region
+  name     = module.datacommons_services[0].service_name
+  role     = "roles/run.developer"
+  member   = "serviceAccount:${module.ingestion_workflow.service_account_email}"
+}
+
+resource "google_service_account_iam_member" "ingestion_workflow_act_as_serving_sa" {
+  count              = var.ingestion_config.enable_ingestion && var.datacommons_services_config.enable ? 1 : 0
+  service_account_id = "projects/${var.global.project_id}/serviceAccounts/${module.datacommons_services[0].service_account_email}"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${module.ingestion_workflow.service_account_email}"
 }

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -109,9 +109,9 @@ variable "ingestion_config" {
     # Dataflow network configuration
     # Use WORKER_IP_PRIVATE when a compute.vmExternalIpAccess org policy
     # blocks Dataflow workers from obtaining external IPs.
-    dataflow_ip_configuration  = optional(string, "WORKER_IP_UNSPECIFIED")
-    dataflow_subnetwork        = optional(string, "")
-    dataflow_template_gcs_path = optional(string)
+    dataflow_ip_configuration    = optional(string, "WORKER_IP_UNSPECIFIED")
+    dataflow_subnetwork          = optional(string, "")
+    dataflow_template_gcs_path   = optional(string)
     dataflow_max_workers         = optional(number, 20)
     dataflow_num_workers         = optional(number, 4)
     dataflow_worker_machine_type = optional(string, "n2-standard-4")


### PR DESCRIPTION
## Overview
Re-enables automatic rolling restarts of the `datacommons-services` Cloud Run instance upon completion of the DCP ingestion Cloud Workflow (`spanner-ingestion-workflow`).

This functionality was previously removed in PR #153,  but we still need it to reload some mixer in memory caches (topic cache and agent service cache)

## Key Changes
1. **Module Configuration (`infra/dcp/modules/ingestion/workflow`)**:
   - Added `enable_datacommons_services_restart` (default `true`) and `datacommons_services_name` variables.
   - Passed variables to `templatefile("${path.module}/workflow.yaml", ...)`.
2. **Cloud Workflow Definition (`workflow.yaml`)**:
   - Added a `restart_service` step calling `googleapis.run.v2.projects.locations.services.patch` to update `template.labels.restarted-at` with dynamic timestamp `sys.now()`.
3. **Stack Wiring & IAM Permissions (`infra/dcp/modules/stack/main.tf`)**:
   - Passed service parameters to `module "ingestion_workflow"`, computing `datacommons_services_name` deterministically to avoid module dependency cycles.
   - Granted resource-level `roles/run.developer` on `dc-datacommons-service` and `roles/iam.serviceAccountUser` (`actAs`) on `dc-srvs-sa` to the workflow service account.

## Testing & Validation
- Ran `terraform fmt` and `terraform validate` successfully.
- Generated and verified execution plan (`terraform plan`) on `test-latest-dcp` deployment.