### PR TITLE
[DCP Terraform] Update BQ Slots default to 100

### DIFF
--- a/infra/dcp/modules/spanner/variables.tf
+++ b/infra/dcp/modules/spanner/variables.tf
@@ -75,5 +75,5 @@ variable "bigquery_reservation_slot_capacity" {
 variable "bigquery_reservation_max_slots" {
   type        = number
   description = "Max slots for BigQuery reservation autoscale"
-  default     = 400
+  default     = 100
 }

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -230,7 +230,7 @@ variable "spanner_bigquery_reservation_slot_capacity" {
 variable "spanner_bigquery_reservation_max_slots" {
   description = "Maximum slots for BigQuery reservation autoscaling"
   type        = number
-  default     = 400
+  default     = 100
 }
 
 # =============================================================================


### PR DESCRIPTION
Public GCP projects only get a max of 100 per project per region.
They must be in multiples of 100, so we have to use 100.