### PR TITLE
clean(infra/dcp): remove obsolete dcp environment variables and redundant embeddings flags

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -100,7 +100,6 @@ locals {
     instructions_path               = var.datacommons_services_mcp_instructions_path != null ? trimsuffix(var.datacommons_services_mcp_instructions_path, "/") : null
     allow_unauthenticated_access    = var.datacommons_services_allow_unauthenticated_access
     website_disable_google_maps_api = var.datacommons_services_website_disable_google_maps_api
-    resolve_with_spanner_embeddings = var.datacommons_services_resolve_with_spanner_embeddings
     website_search_scope            = var.datacommons_services_website_search_scope
   }
 

--- a/infra/dcp/modules/datacommons_services/main.tf
+++ b/infra/dcp/modules/datacommons_services/main.tf
@@ -13,7 +13,7 @@ locals {
       "roles/workflows.invoker"
     ],
     var.use_spanner ? ["roles/spanner.databaseUser"] : [],
-    var.use_spanner && var.resolve_with_spanner_embeddings ? ["roles/aiplatform.user"] : []
+    var.use_spanner ? ["roles/aiplatform.user"] : []
   ))
 }
 
@@ -100,18 +100,6 @@ resource "google_cloud_run_v2_service" "dc_web_service" {
       env {
         name  = "DC_INSTRUCTIONS_DIR"
         value = var.mcp_instructions_path != null ? "gs://${var.artifacts_bucket_name}/${var.mcp_instructions_path}" : ""
-      }
-      env {
-        name  = "RESOLVE_WITH_SPANNER_EMBEDDINGS"
-        value = var.resolve_with_spanner_embeddings ? "true" : "false"
-      }
-      env {
-        name  = "ENABLE_UNIQUE_HISTORY_RECORDS"
-        value = "true"
-      }
-      env {
-        name  = "USE_SPANNER_KEY_VALUE_STORE"
-        value = var.use_spanner ? "true" : "false"
       }
       env {
         name  = "V2_RESOLVE_INDICATORS_TARGET"

--- a/infra/dcp/modules/datacommons_services/variables.tf
+++ b/infra/dcp/modules/datacommons_services/variables.tf
@@ -69,9 +69,6 @@ variable "mcp_instructions_path" {
   default     = null
 }
 
-variable "resolve_with_spanner_embeddings" {
-  type = bool
-}
 
 variable "website_search_scope" {
   type        = string

--- a/infra/dcp/modules/ingestion/helper_service/main.tf
+++ b/infra/dcp/modules/ingestion/helper_service/main.tf
@@ -72,11 +72,6 @@ resource "google_cloud_run_v2_service" "ingestion_helper" {
         name  = "REDIS_PORT"
         value = var.redis_port
       }
-      env {
-        name  = "ENABLE_UNIQUE_INGESTION_RUNS"
-        value = "true"
-        # Temporary variable to control changes to the ingestion history table. To be deleted after migration complete.
-      }
     }
 
     dynamic "vpc_access" {

--- a/infra/dcp/modules/stack/main.tf
+++ b/infra/dcp/modules/stack/main.tf
@@ -128,7 +128,7 @@ module "ingestion_preprocessing_job" {
   ingestion_artifacts_path      = var.ingestion_config.ingestion_artifacts_path
   run_database_init             = false
   use_spanner                   = true
-  enable_spanner_embeddings     = var.datacommons_services_config.resolve_with_spanner_embeddings
+  enable_spanner_embeddings     = var.spanner_config.enable_embeddings_generation
   env_vars                      = local.cloud_run_shared_env_variables
   env_secrets = {
     DC_API_KEY = {
@@ -286,7 +286,6 @@ module "datacommons_services" {
     }
   ])
   secret_env_vars                 = local.datacommons_services_secrets
-  resolve_with_spanner_embeddings = var.datacommons_services_config.resolve_with_spanner_embeddings
   website_search_scope            = var.datacommons_services_config.website_search_scope
 
   depends_on = [module.ingestion_preprocessing_job]

--- a/infra/dcp/modules/stack/variables.tf
+++ b/infra/dcp/modules/stack/variables.tf
@@ -50,7 +50,6 @@ variable "datacommons_services_config" {
     instructions_path               = string
     allow_unauthenticated_access    = bool
     website_disable_google_maps_api = bool
-    resolve_with_spanner_embeddings = bool
     website_search_scope            = optional(string, "")
   })
 }

--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -315,12 +315,6 @@ variable "datacommons_services_mcp_instructions_path" {
   default     = null
 }
 
-# TODO(shixiao): Remove this variable to only resolve on spanner embeddings
-variable "datacommons_services_resolve_with_spanner_embeddings" {
-  description = "Enable resolving search queries with Spanner embeddings. Requires Spanner to be enabled (enable_spanner = true)."
-  type        = bool
-  default     = true
-}
 
 variable "datacommons_services_website_search_scope" {
   description = "Controls the scope for indicator resolution on the website Explore page (e.g., restricting queries to custom variables). Valid values are 'base_only', 'custom_only', 'base_and_custom'."

--- a/tests/datacommons-integration-tests/README.md
+++ b/tests/datacommons-integration-tests/README.md
@@ -50,7 +50,7 @@ While running with `--keep-containers`, you can access:
 
 Local integration tests run with the Spanner multi-entity schema enabled by default in the Mixer backend. This is controlled by mounting [custom_feature_flags.yaml](./custom_feature_flags.yaml) inside the `website` container at `/workspace/deploy/featureflags/custom.yaml`.
 
-The container entrypoint detects the environment variable `RESOLVE_WITH_SPANNER_EMBEDDINGS=true` (defined in `docker-compose.test.yml`) and starts Mixer using these flags.
+The container entrypoint starts Mixer using canonical feature flags along with these test overrides.
 
 You can modify the flags inside `custom_feature_flags.yaml` if you need to tweak the Mixer server configuration for local debugging.
 

--- a/tests/datacommons-integration-tests/custom_feature_flags.yaml
+++ b/tests/datacommons-integration-tests/custom_feature_flags.yaml
@@ -1,6 +1,6 @@
 # This file overrides Mixer feature flags for local integration tests.
 # It is mounted as '/workspace/deploy/featureflags/custom.yaml' inside the website container,
-# which gets activated when RESOLVE_WITH_SPANNER_EMBEDDINGS=true is set in the environment.
+# which overrides canonical feature flags when running local docker-compose tests.
 #
 # Doing this enables testing the new schema layout without changing production website code.
 flags:

--- a/tests/datacommons-integration-tests/docker-compose.test.yml
+++ b/tests/datacommons-integration-tests/docker-compose.test.yml
@@ -88,7 +88,6 @@ services:
       - SPANNER_EMULATOR_HOST=spanner:${SPANNER_INTERNAL_GRPC_PORT:-15000}
       - STORAGE_EMULATOR_HOST=http://gcs:9099
       - OUTPUT_DIR=gs://test-bucket/output
-      - RESOLVE_WITH_SPANNER_EMBEDDINGS=true
       - PROJECT_ID=default
       - GCP_PROJECT_ID=default
       - GCP_SPANNER_INSTANCE_ID=default


### PR DESCRIPTION
## Overview
Removes obsolete environment variables and redundant Terraform variables across DCP infrastructure (`infra/dcp`) and integration test configurations, aligning with recent `cdc_services` cleanup in `datcom-website`.

## Changes
- **Datacommons Services Module**: Removed obsolete environment variables `RESOLVE_WITH_SPANNER_EMBEDDINGS`, `ENABLE_UNIQUE_HISTORY_RECORDS`, and `USE_SPANNER_KEY_VALUE_STORE` from the Cloud Run container definition. Simplified IAM role condition for `roles/aiplatform.user` to `var.use_spanner`.
- **Ingestion Helper Module**: Removed temporary migration environment variable `ENABLE_UNIQUE_INGESTION_RUNS`.
- **Stack & Top-Level Modules**: Removed redundant `resolve_with_spanner_embeddings` / `datacommons_services_resolve_with_spanner_embeddings` variable definitions and pass-throughs. Aligned `ingestion_preprocessing_job` to pass `enable_spanner_embeddings = var.spanner_config.enable_embeddings_generation`.
- **Integration Tests**: Removed `- RESOLVE_WITH_SPANNER_EMBEDDINGS=true` override from `docker-compose.test.yml` and updated documentation/comments in `custom_feature_flags.yaml` and `README.md`.

## Verification
- Validated template generation and CLI tests via `uv run pytest packages/datacommons-admin/tests/test_admin_cli.py`.
- Verified Terraform syntax and module integrity via `terraform validate`.