### PR TITLE
fix(deploy): update VERSION in staging.yaml and enforce tag validation in release.yaml

### DIFF
--- a/deploy/release.yaml
+++ b/deploy/release.yaml
@@ -22,8 +22,12 @@ steps:
       - '-c'
       - |
         tag_version=$${TAG_NAME#v}
-        echo "Updating version files to $tag_version"
-        echo "$tag_version" > VERSION
+        version_in_file=$(tr -d '[:space:]' < VERSION)
+        echo "Validating release tag '$tag_version' against VERSION file '$version_in_file'..."
+        if [ "$tag_version" != "$version_in_file" ]; then
+          echo "ERROR: Release tag ($tag_version) does not match VERSION file ($version_in_file)."
+          exit 1
+        fi
         python3 -c "import glob, re; [open(f, 'w').write(re.sub(r'^__version__ = [\"\'].*[\"\']', '__version__ = \"'\"$tag_version\"'\"', content, flags=re.MULTILINE)) for f in glob.glob('packages/*/datacommons_*/__init__.py') for content in [open(f, 'r').read()]]"
         python3 -c "import re; [open('pyproject.toml', 'w').write(re.sub(r'^version = \".*\"', 'version = \"'\"$tag_version\"'\"', content, flags=re.MULTILINE)) for content in [open('pyproject.toml', 'r').read()]]"
 

--- a/deploy/release.yaml
+++ b/deploy/release.yaml
@@ -29,7 +29,6 @@ steps:
           exit 1
         fi
         python3 -c "import glob, re; [open(f, 'w').write(re.sub(r'^__version__ = [\"\'].*[\"\']', '__version__ = \"'\"$tag_version\"'\"', content, flags=re.MULTILINE)) for f in glob.glob('packages/*/datacommons_*/__init__.py') for content in [open(f, 'r').read()]]"
-        python3 -c "import re; [open('pyproject.toml', 'w').write(re.sub(r'^version = \".*\"', 'version = \"'\"$tag_version\"'\"', content, flags=re.MULTILINE)) for content in [open('pyproject.toml', 'r').read()]]"
 
   # 2. Build and publish all Python packages to PyPI
   - name: 'ghcr.io/astral-sh/uv:python3.12-trixie-slim'

--- a/deploy/release.yaml
+++ b/deploy/release.yaml
@@ -23,6 +23,7 @@ steps:
       - |
         tag_version=$${TAG_NAME#v}
         echo "Updating version files to $tag_version"
+        echo "$tag_version" > VERSION
         python3 -c "import glob, re; [open(f, 'w').write(re.sub(r'^__version__ = [\"\'].*[\"\']', '__version__ = \"'\"$tag_version\"'\"', content, flags=re.MULTILINE)) for f in glob.glob('packages/*/datacommons_*/__init__.py') for content in [open(f, 'r').read()]]"
         python3 -c "import re; [open('pyproject.toml', 'w').write(re.sub(r'^version = \".*\"', 'version = \"'\"$tag_version\"'\"', content, flags=re.MULTILINE)) for content in [open('pyproject.toml', 'r').read()]]"
 

--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -25,7 +25,6 @@ steps:
         echo "Updating version files to $tag_version"
         echo "$tag_version" > VERSION
         python3 -c "import glob, re; [open(f, 'w').write(re.sub(r'^__version__ = [\"\'].*[\"\']', '__version__ = \"'\"$tag_version\"'\"', content, flags=re.MULTILINE)) for f in glob.glob('packages/*/datacommons_*/__init__.py') for content in [open(f, 'r').read()]]"
-        python3 -c "import re; [open('pyproject.toml', 'w').write(re.sub(r'^version = \".*\"', 'version = \"'\"$tag_version\"'\"', content, flags=re.MULTILINE)) for content in [open('pyproject.toml', 'r').read()]]"
 
   # 2. Build and publish all Python packages to TestPyPI
   - name: 'ghcr.io/astral-sh/uv:python3.12-trixie-slim'

--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -23,6 +23,7 @@ steps:
       - |
         tag_version=$${TAG_NAME#v}
         echo "Updating version files to $tag_version"
+        echo "$tag_version" > VERSION
         python3 -c "import glob, re; [open(f, 'w').write(re.sub(r'^__version__ = [\"\'].*[\"\']', '__version__ = \"'\"$tag_version\"'\"', content, flags=re.MULTILINE)) for f in glob.glob('packages/*/datacommons_*/__init__.py') for content in [open(f, 'r').read()]]"
         python3 -c "import re; [open('pyproject.toml', 'w').write(re.sub(r'^version = \".*\"', 'version = \"'\"$tag_version\"'\"', content, flags=re.MULTILINE)) for content in [open('pyproject.toml', 'r').read()]]"
 


### PR DESCRIPTION
### Summary
Fixes package versioning behavior across staging and production Cloud Build release pipelines.

### Changes Included
1. **Staging Builds (`deploy/staging.yaml`):** Overwrites the `VERSION` file dynamically (`echo "$tag_version" > VERSION`) during pre-release builds so setuptools packages release candidate versions (e.g. `1.1.1rc2`) correctly when publishing to TestPyPI.
2. **Production Releases (`deploy/release.yaml`):** Enforces a strict validation check requiring `$tag_version` to match the `VERSION` file checked into Git. If there is any version mismatch, Cloud Build fails immediately before publishing to production PyPI.