### PR TITLE
fix(infra): enable Maps JavaScript and Places APIs in terraform

### DIFF
--- a/infra/dcp/main.tf
+++ b/infra/dcp/main.tf
@@ -32,6 +32,8 @@ provider "google-beta" {
 resource "google_project_service" "apis" {
   for_each = toset(concat([
     "apikeys.googleapis.com",
+    "maps-backend.googleapis.com",
+    "places-backend.googleapis.com",
     "run.googleapis.com",
     "iam.googleapis.com",
     "cloudresourcemanager.googleapis.com",


### PR DESCRIPTION
## Description
This PR enables `maps-backend.googleapis.com` (Maps JavaScript API) and `places-backend.googleapis.com` (Places API) in `google_project_service.apis` inside `infra/dcp/main.tf`.

## Context
When deploying Data Commons Platform (DCP) via Terraform, the Timelines Explorer and other visualization tools on `datcom-website` use Google Maps Places Autocomplete (`google.maps.places.Autocomplete`).

While Terraform created the restricted API key in `modules/auth/main.tf`, the underlying GCP project services (`maps-backend.googleapis.com` and `places-backend.googleapis.com`) were not enabled in `google_project_service.apis`, causing place autocomplete and map features to fail with `ApiNotActivatedMapError`.

## Changes
- Updated `infra/dcp/main.tf` to include `maps-backend.googleapis.com` and `places-backend.googleapis.com` in `google_project_service.apis`.
