### PR TITLE
[DCP Ingestion] Fix lock acquisition retry following a change in error code.

### DIFF
--- a/infra/dcp/modules/ingestion/workflow/workflow.yaml
+++ b/infra/dcp/modules/ingestion/workflow/workflow.yaml
@@ -150,7 +150,7 @@ main:
           steps:
             - handle_lock_busy:
                 switch:
-                  - condition: '$${default(map.get(e, "code"), 0) == 400 and lock_retries < max_lock_retries}'
+                  - condition: '$${default(map.get(e, "code"), 0) == 503 and lock_retries < max_lock_retries}'
                     next: increment_retries_and_wait
             - unhandled_error:
                 raise: $${e}


### PR DESCRIPTION
Error code was changed from 400 to 503 in https://github.com/datacommonsorg/import/pull/697/changes

It  broke the retry logic, this will fix it. I wonder if there's a better error code to use though? Food for thought.