### PR TITLE
feat(infra): add validation for instance_name and namespace variables

### DIFF
--- a/infra/dcp/variables.tf
+++ b/infra/dcp/variables.tf
@@ -17,12 +17,22 @@ variable "instance_name" {
   description = "A unique identifier used as a prefix for resource naming. This prevents naming conflicts when deploying multiple isolated environments (like dev, staging, or feature branches) within the same GCP project."
   type        = string
   default     = ""
+
+  validation {
+    condition     = var.instance_name == "" || (length(var.instance_name) <= 16 && can(regex("^[a-z]([-a-z0-9]*[a-z0-9])?$", var.instance_name)))
+    error_message = "The instance_name must be at most 16 characters long, start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, and hyphens."
+  }
 }
 
 variable "namespace" {
   description = "Deprecated alias for instance_name. Used to maintain backward-compatibility with existing Terraform configurations."
   type        = string
   default     = ""
+
+  validation {
+    condition     = var.namespace == "" || (length(var.namespace) <= 16 && can(regex("^[a-z]([-a-z0-9]*[a-z0-9])?$", var.namespace)))
+    error_message = "The namespace must be at most 16 characters long, start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, and hyphens."
+  }
 }
 
 variable "stateful_deletion_protection" {


### PR DESCRIPTION
### Summary
Adds input validation rules for `instance_name` and `namespace` variables in `infra/dcp/variables.tf`.

### Context & Problem
Google Cloud Service Account `account_id` values have a strict limit of 6 to 30 characters and must match `^[a-z]([-a-z0-9]*[a-z0-9])?$`.

Several DCP modules append fixed suffixes up to 14 characters long (e.g. `-dc-ing-hlp-sa`, `-dc-ing-pre-sa`, `-dc-ing-pst-sa`) to the `instance_name` when generating Service Account names. Consequently, setting an `instance_name` longer than 16 characters causes Terraform planning / API execution to fail with downstream errors like:
```text
Error: "account_id" ("dcp-custom-var-test-dc-ing-df-sa") must be between 6 and 30 characters long
