### PR TITLE
feat(deploy): automate release artifact cross-tagging and pre-publish validation gates

### DIFF
--- a/deploy/bump_version.yaml
+++ b/deploy/bump_version.yaml
@@ -1,5 +1,27 @@
 steps:
+  # 1. Optionally tag release artifacts if promoting from a verified release candidate
+  - name: 'google/cloud-sdk:slim'
+    id: 'promote-release-artifacts'
+    entrypoint: 'bash'
+    env:
+      - 'NEW_VERSION=${_NEW_VERSION}'
+      - 'PROMOTED_CANDIDATE_TAG=${_PROMOTED_CANDIDATE_TAG}'
+    args:
+      - '-c'
+      - |
+        set -eo pipefail
+        if [ -n "$$PROMOTED_CANDIDATE_TAG" ]; then
+          echo "Promoting release artifacts from candidate '$$PROMOTED_CANDIDATE_TAG' to target '$$NEW_VERSION'..."
+          python3 deploy/scripts/tag_release_artifacts.py \
+            --target-tag "$$NEW_VERSION" \
+            --default-source-tag "$$PROMOTED_CANDIDATE_TAG"
+        else
+          echo "No candidate tag (_PROMOTED_CANDIDATE_TAG) provided; skipping artifact promotion tagging."
+        fi
+
+  # 2. Update version files, lockfile, commit, and create bump PR
   - name: 'ghcr.io/astral-sh/uv:python3.12-trixie-slim'
+    id: 'create-bump-pr'
     entrypoint: bash
     secretEnv: ['GH_TOKEN']
     env: ['NEW_VERSION=${_NEW_VERSION}']
@@ -56,14 +78,13 @@ steps:
             --head "$$BRANCH_NAME"
         fi
 
-
-
 substitutions:
   _GITHUB_AUTHOR: 'datacommons-robot-author'
   _GITHUB_ORG: 'datacommonsorg'
   _GITHUB_REPO: 'datacommons'
   _GITHUB_BRANCH: 'main'
   _NEW_VERSION: ''
+  _PROMOTED_CANDIDATE_TAG: ''
 
 availableSecrets:
   secretManager:

--- a/deploy/release.yaml
+++ b/deploy/release.yaml
@@ -13,10 +13,14 @@
 # limitations under the License.
 
 steps:
-  # 1. Validate version consistency across VERSION files, pyproject.toml, and variables.tf
-  - name: 'ghcr.io/astral-sh/uv:python3.12-trixie-slim'
+  # 1. Validate version consistency across local manifests and remote release artifacts
+  - name: 'google/cloud-sdk:slim'
+    id: 'validate-release-version'
     entrypoint: 'python3'
-    args: ['deploy/scripts/validate_release_version.py', '$TAG_NAME']
+    args:
+      - 'deploy/scripts/validate_release_version.py'
+      - '$TAG_NAME'
+      - '--check-remote-artifacts'
 
   # 2. Build and publish all Python packages to PyPI
   - name: 'ghcr.io/astral-sh/uv:python3.12-trixie-slim'

--- a/deploy/scripts/tag_release_artifacts.py
+++ b/deploy/scripts/tag_release_artifacts.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""tag_release_artifacts.py - Multi-Artifact Release Tagging & Template Staging.
+
+PURPOSE:
+  Automates the cross-tagging of container images and the staging/re-rendering
+  of the Dataflow Flex Template JSON spec across GCR, Artifact Registry, and GCS.
+
+ARTIFACTS MANAGED:
+  1. Services Image:            gcr.io/datcom-ci/datacommons-services
+  2. Preprocessor Image:        gcr.io/datcom-ci/datacommons-data
+  3. Postprocessor Image:       gcr.io/datcom-ci/datacommons-aggregation-helper
+  4. Ingestion Helper Image:    gcr.io/datcom-ci/datacommons-ingestion-helper
+  5. Dataflow Worker Image:     us-docker.pkg.dev/datcom-ci/gcr.io/dataflow-templates/ingestion
+  6. Dataflow Flex Template:    gs://datcom-templates/templates/flex/ingestion-<TAG>.json
+
+NOTE ON INTENTIONAL SELF-CONTAINMENT:
+  This script is intentionally self-contained using only the Python standard library
+  so that it can run reliably inside minimal Cloud Build builders (e.g. google/cloud-sdk:slim)
+  without PYTHONPATH configuration or external PyPI dependencies.
+
+USAGE EXAMPLES:
+  # 1. Staging candidate with a default baseline and a services commit override:
+  python3 deploy/scripts/tag_release_artifacts.py \\
+    --target-tag "1.1.2rc1" \\
+    --default-source-tag "1.1.1" \\
+    --services-tag "1574ed3-79627f8-e265a1d"
+
+  # 2. Promoting a verified release candidate to production:
+  python3 deploy/scripts/tag_release_artifacts.py \\
+    --target-tag "1.1.2" \\
+    --default-source-tag "1.1.2rc1"
+
+  # 3. Dry-run inspection:
+  python3 deploy/scripts/tag_release_artifacts.py \\
+    --target-tag "1.1.2rc1" \\
+    --default-source-tag "1.1.1" \\
+    --dry-run
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Single Source of Truth: Registry image repository mappings
+ARTIFACT_IMAGE_MAP = {
+    "services": "gcr.io/datcom-ci/datacommons-services",
+    "preprocessor": "gcr.io/datcom-ci/datacommons-data",
+    "postprocessor": "gcr.io/datcom-ci/datacommons-aggregation-helper",
+    "ingestion_helper": "gcr.io/datcom-ci/datacommons-ingestion-helper",
+    "dataflow": "us-docker.pkg.dev/datcom-ci/gcr.io/dataflow-templates/ingestion",
+}
+
+DEFAULT_TEMPLATE_GCS_BASE = "gs://datcom-templates/templates/flex"
+
+# Anchored SemVer / PEP 440 regex matching releases (1.2.3), pre-releases (1.2.3rc1),
+# and development versions (1.2.0.dev0).
+VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?(?:\.dev\d+)?$")
+
+
+def normalize_tag(tag: str) -> str:
+    """Strips whitespace and leading 'v' prefix from version tags."""
+    return tag.strip().lstrip("v").strip()
+
+
+def tag_container_image(
+    repo: str,
+    src_tag: str,
+    target_tag: str,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Adds a new tag to an existing container image in GCR/Artifact Registry."""
+    src_image = f"{repo}:{src_tag}"
+    target_image = f"{repo}:{target_tag}"
+
+    cmd = [
+        "gcloud",
+        "container",
+        "images",
+        "add-tag",
+        src_image,
+        target_image,
+        "--quiet",
+    ]
+
+    print(f"  [IMAGE] Tagging {src_image} -> {target_image}")
+    if dry_run:
+        print(f"          [DRY-RUN] Executing: {' '.join(cmd)}")
+        return
+
+    try:
+        res = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        if res.stdout.strip():
+            print(f"          {res.stdout.strip()}")
+    except subprocess.CalledProcessError as e:
+        sys.exit(
+            f"Error: Failed to tag image '{src_image}' -> '{target_image}'.\n"
+            f"Command: {' '.join(cmd)}\n"
+            f"Details: {e.stderr.strip() or e.stdout.strip()}"
+        )
+
+
+def stage_dataflow_template(
+    gcs_base: str,
+    src_tag: str,
+    target_tag: str,
+    dataflow_image_repo: str,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Downloads source template spec, updates internal image pointer, and uploads to target."""
+    src_uri = f"{gcs_base.rstrip('/')}/ingestion-{src_tag}.json"
+    target_uri = f"{gcs_base.rstrip('/')}/ingestion-{target_tag}.json"
+    target_image = f"{dataflow_image_repo}:{target_tag}"
+
+    print("  [TEMPLATE] Staging Dataflow Flex Template:")
+    print(f"             Source:      {src_uri}")
+    print(f"             Destination: {target_uri}")
+    print(f"             Image Ref:   {target_image}")
+
+    if dry_run:
+        print(
+            f"             [DRY-RUN] Would download {src_uri}, set image={target_image}, and upload to {target_uri}"
+        )
+        return
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        local_src = tmp_path / f"ingestion-{src_tag}.json"
+        local_target = tmp_path / f"ingestion-{target_tag}.json"
+
+        # 1. Download source template spec
+        cp_in_cmd = ["gcloud", "storage", "cp", src_uri, str(local_src)]
+        try:
+            subprocess.run(
+                cp_in_cmd,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            sys.exit(
+                f"Error: Failed to download source Dataflow template '{src_uri}'.\n"
+                f"Command: {' '.join(cp_in_cmd)}\n"
+                f"Details: {e.stderr.strip() or e.stdout.strip()}"
+            )
+
+        # 2. Parse and update image pointer inside JSON
+        try:
+            data = json.loads(local_src.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as e:
+            sys.exit(
+                f"Error: Failed to parse JSON in downloaded template '{src_uri}': {e}"
+            )
+
+        data["image"] = target_image
+        local_target.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+        # 3. Upload updated template spec to target URI
+        cp_out_cmd = ["gcloud", "storage", "cp", str(local_target), target_uri]
+        try:
+            subprocess.run(
+                cp_out_cmd,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            sys.exit(
+                f"Error: Failed to upload updated Dataflow template to '{target_uri}'.\n"
+                f"Command: {' '.join(cp_out_cmd)}\n"
+                f"Details: {e.stderr.strip() or e.stdout.strip()}"
+            )
+
+
+def tag_all_artifacts(
+    target_tag: str,
+    default_source_tag: str | None = None,
+    services_tag: str | None = None,
+    preprocessor_tag: str | None = None,
+    postprocessor_tag: str | None = None,
+    ingestion_helper_tag: str | None = None,
+    dataflow_tag: str | None = None,
+    template_gcs_base: str = DEFAULT_TEMPLATE_GCS_BASE,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Resolves tags for all artifacts and coordinates container tagging and template staging."""
+    target_tag = normalize_tag(target_tag)
+    if not target_tag:
+        sys.exit("Error: Target tag cannot be empty.")
+    if not VERSION_PATTERN.match(target_tag):
+        sys.exit(
+            f"Error: Invalid target tag format '{target_tag}'. "
+            "Must follow SemVer / PEP 440 (e.g. '1.2.3' or '1.2.3rc1')."
+        )
+
+    # Resolve source tags with fallback hierarchy
+    default_src = normalize_tag(default_source_tag) if default_source_tag else None
+    resolved_sources = {
+        "services": normalize_tag(services_tag) if services_tag else default_src,
+        "preprocessor": (
+            normalize_tag(preprocessor_tag) if preprocessor_tag else default_src
+        ),
+        "postprocessor": (
+            normalize_tag(postprocessor_tag) if postprocessor_tag else default_src
+        ),
+        "ingestion_helper": (
+            normalize_tag(ingestion_helper_tag) if ingestion_helper_tag else default_src
+        ),
+        "dataflow": (normalize_tag(dataflow_tag) if dataflow_tag else default_src),
+    }
+
+    # Validate that every artifact has a resolved source tag
+    missing_sources = [k for k, v in resolved_sources.items() if not v]
+    if missing_sources:
+        sys.exit(
+            f"Error: Missing source tag for artifact(s): {', '.join(missing_sources)}.\n"
+            f"Please specify --default-source-tag or provide specific --<artifact>-tag flags."
+        )
+
+    print("=" * 72)
+    print(f"RELEASE ARTIFACT TAGGING PLAN -> Target: '{target_tag}'")
+    print("=" * 72)
+    for artifact, repo in ARTIFACT_IMAGE_MAP.items():
+        src = resolved_sources[artifact]
+        print(f"  * {artifact:<18}: {src} -> {target_tag} ({repo})")
+    print(
+        f"  * {'flex_template':<18}: ingestion-{resolved_sources['dataflow']}.json -> ingestion-{target_tag}.json"
+    )
+    print("=" * 72)
+
+    # 1. Tag container images
+    print("\n1. Tagging Container Images:")
+    for artifact, repo in ARTIFACT_IMAGE_MAP.items():
+        src = resolved_sources[artifact]
+        tag_container_image(
+            repo=repo,
+            src_tag=src,
+            target_tag=target_tag,
+            dry_run=dry_run,
+        )
+
+    # 2. Stage Dataflow Flex Template JSON
+    print("\n2. Staging Dataflow Flex Template:")
+    stage_dataflow_template(
+        gcs_base=template_gcs_base,
+        src_tag=resolved_sources["dataflow"],
+        target_tag=target_tag,
+        dataflow_image_repo=ARTIFACT_IMAGE_MAP["dataflow"],
+        dry_run=dry_run,
+    )
+
+    print("\nAll release artifacts tagged and staged successfully!")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Tag and stage release container images and Dataflow Flex Templates."
+    )
+    parser.add_argument(
+        "--target-tag",
+        required=True,
+        help="The target release version or candidate tag (e.g. 1.1.2 or 1.1.2rc1).",
+    )
+    parser.add_argument(
+        "--default-source-tag",
+        help="Default baseline source tag inherited by all artifacts unless explicitly overridden.",
+    )
+    parser.add_argument(
+        "--services-tag",
+        "--services-source-tag",
+        dest="services_tag",
+        help="Source tag or commit SHA for datacommons-services image.",
+    )
+    parser.add_argument(
+        "--preprocessor-tag",
+        "--preprocessor-source-tag",
+        dest="preprocessor_tag",
+        help="Source tag for datacommons-data (preprocessor) image.",
+    )
+    parser.add_argument(
+        "--postprocessor-tag",
+        "--postprocessor-source-tag",
+        dest="postprocessor_tag",
+        help="Source tag for datacommons-aggregation-helper (postprocessor) image.",
+    )
+    parser.add_argument(
+        "--ingestion-helper-tag",
+        "--ingestion-helper-source-tag",
+        dest="ingestion_helper_tag",
+        help="Source tag for datacommons-ingestion-helper image.",
+    )
+    parser.add_argument(
+        "--dataflow-tag",
+        "--dataflow-source-tag",
+        dest="dataflow_tag",
+        help="Source tag for Dataflow worker image and template spec.",
+    )
+    parser.add_argument(
+        "--template-bucket",
+        default=DEFAULT_TEMPLATE_GCS_BASE,
+        help=f"GCS bucket directory for Dataflow Flex Templates (default: {DEFAULT_TEMPLATE_GCS_BASE}).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned operations without executing gcloud tagging or uploads.",
+    )
+
+    args = parser.parse_args()
+
+    tag_all_artifacts(
+        target_tag=args.target_tag,
+        default_source_tag=args.default_source_tag,
+        services_tag=args.services_tag,
+        preprocessor_tag=args.preprocessor_tag,
+        postprocessor_tag=args.postprocessor_tag,
+        ingestion_helper_tag=args.ingestion_helper_tag,
+        dataflow_tag=args.dataflow_tag,
+        template_gcs_base=args.template_bucket,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/scripts/tag_release_artifacts.py
+++ b/deploy/scripts/tag_release_artifacts.py
@@ -92,15 +92,27 @@ def tag_container_image(
     src_image = f"{repo}:{src_tag}"
     target_image = f"{repo}:{target_tag}"
 
-    cmd = [
-        "gcloud",
-        "container",
-        "images",
-        "add-tag",
-        src_image,
-        target_image,
-        "--quiet",
-    ]
+    if "pkg.dev" in repo:
+        cmd = [
+            "gcloud",
+            "artifacts",
+            "docker",
+            "tags",
+            "add",
+            src_image,
+            target_image,
+            "--quiet",
+        ]
+    else:
+        cmd = [
+            "gcloud",
+            "container",
+            "images",
+            "add-tag",
+            src_image,
+            target_image,
+            "--quiet",
+        ]
 
     print(f"  [IMAGE] Tagging {src_image} -> {target_image}")
     if dry_run:
@@ -180,7 +192,7 @@ def stage_dataflow_template(
             )
 
         data["image"] = target_image
-        local_target.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        local_target.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
         # 3. Upload updated template spec to target URI
         cp_out_cmd = ["gcloud", "storage", "cp", str(local_target), target_uri]

--- a/deploy/scripts/tag_release_artifacts.py
+++ b/deploy/scripts/tag_release_artifacts.py
@@ -54,6 +54,7 @@ USAGE EXAMPLES:
 import argparse
 import json
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -171,7 +172,9 @@ def stage_dataflow_template(
         # 2. Parse and update image pointer inside JSON
         try:
             data = json.loads(local_src.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as e:
+            if not isinstance(data, dict):
+                raise ValueError("Template JSON root must be a dictionary object.")
+        except (json.JSONDecodeError, OSError, ValueError) as e:
             sys.exit(
                 f"Error: Failed to parse JSON in downloaded template '{src_uri}': {e}"
             )
@@ -216,6 +219,13 @@ def tag_all_artifacts(
         sys.exit(
             f"Error: Invalid target tag format '{target_tag}'. "
             "Must follow SemVer / PEP 440 (e.g. '1.2.3' or '1.2.3rc1')."
+        )
+
+    # Validate gcloud availability when performing actual execution
+    if not dry_run and not shutil.which("gcloud"):
+        sys.exit(
+            "Error: 'gcloud' command-line tool not found in PATH. "
+            "Please ensure Google Cloud SDK is installed and in your PATH."
         )
 
     # Resolve source tags with fallback hierarchy

--- a/deploy/scripts/validate_release_version.py
+++ b/deploy/scripts/validate_release_version.py
@@ -16,8 +16,9 @@
 """validate_release_version.py - Pre-publish Version Consistency Validator.
 
 PURPOSE:
-  Validates that all monorepo version declarations and dependency pins strictly
-  match the target release version tag before publishing packages to PyPI.
+  Validates that all monorepo version declarations, dependency pins, container
+  images, and Dataflow Flex Templates strictly match the target release version
+  tag before publishing packages to PyPI.
 
 CHECKS PERFORMED:
   1. Release tag/version matches SemVer / PEP 440 format.
@@ -25,6 +26,8 @@ CHECKS PERFORMED:
   3. All subpackage packages/*/VERSION files match target version.
   4. packages/datacommons-cli/pyproject.toml locks datacommons-admin to ==target_version.
   5. infra/dcp/variables.tf declares dcp_version default matching target_version.
+  6. (Optional/CI via --check-remote-artifacts) All 5 container images exist in GCR/Artifact Registry.
+  7. (Optional/CI via --check-remote-artifacts) Dataflow Flex Template spec exists in GCS.
 
 NOTE ON INTENTIONAL SELF-CONTAINMENT:
   This script is intentionally self-contained with zero local helper imports so that
@@ -37,11 +40,12 @@ USAGE:
   python3 deploy/scripts/validate_release_version.py <TAG_OR_VERSION>
   Example:
     python3 deploy/scripts/validate_release_version.py 1.2.3
-    python3 deploy/scripts/validate_release_version.py v1.2.3
+    python3 deploy/scripts/validate_release_version.py v1.2.3 --check-remote-artifacts
 """
 
 import argparse
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -52,8 +56,24 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # Synchronized with apply_version_bump.py.
 VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?(?:\.dev\d+)?$")
 
+# Registry mappings for remote artifact verification
+ARTIFACT_IMAGE_MAP = {
+    "services": "gcr.io/datcom-ci/datacommons-services",
+    "preprocessor": "gcr.io/datcom-ci/datacommons-data",
+    "postprocessor": "gcr.io/datcom-ci/datacommons-aggregation-helper",
+    "ingestion_helper": "gcr.io/datcom-ci/datacommons-ingestion-helper",
+    "dataflow": "us-docker.pkg.dev/datcom-ci/gcr.io/dataflow-templates/ingestion",
+}
 
-def validate_release_version(tag_or_version: str) -> None:
+DEFAULT_TEMPLATE_GCS_BASE = "gs://datcom-templates/templates/flex"
+
+
+def validate_release_version(
+    tag_or_version: str,
+    *,
+    check_remote_artifacts: bool = False,
+    template_gcs_base: str = DEFAULT_TEMPLATE_GCS_BASE,
+) -> None:
     """Validates all version declarations match the target release version."""
     target_version = tag_or_version.strip().lstrip("v").strip()
     if not target_version:
@@ -160,6 +180,42 @@ def validate_release_version(tag_or_version: str) -> None:
         else:
             print(f"  [OK] infra/dcp/variables.tf (dcp_version default): {m.group(1)}")
 
+    # 5. Optional / CI: Validate remote release artifacts (images & GCS template)
+    if check_remote_artifacts:
+        print("\nValidating remote release artifacts exist...")
+
+        # A. Check container images in GCR/Artifact Registry
+        for artifact, repo in ARTIFACT_IMAGE_MAP.items():
+            image_ref = f"{repo}:{target_version}"
+            cmd = [
+                "gcloud",
+                "container",
+                "images",
+                "describe",
+                image_ref,
+                "--format=json",
+            ]
+            res = subprocess.run(cmd, check=False, capture_output=True, text=True)
+            if res.returncode != 0:
+                errors.append(
+                    f"Remote container image '{image_ref}' does not exist in registry."
+                )
+            else:
+                print(f"  [OK] Container Image ({artifact}): {image_ref}")
+
+        # B. Check Dataflow Flex Template spec in GCS
+        template_uri = (
+            f"{template_gcs_base.rstrip('/')}/ingestion-{target_version}.json"
+        )
+        cmd = ["gcloud", "storage", "ls", template_uri]
+        res = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        if res.returncode != 0:
+            errors.append(
+                f"Dataflow Flex Template spec '{template_uri}' does not exist in GCS."
+            )
+        else:
+            print(f"  [OK] Dataflow Flex Template: {template_uri}")
+
     if errors:
         print("\nRelease validation FAILED with the following error(s):")
         for err in errors:
@@ -177,8 +233,22 @@ def main() -> None:
         "tag_or_version",
         help="The release tag or version string (e.g. v1.2.3 or 1.2.3)",
     )
+    parser.add_argument(
+        "--check-remote-artifacts",
+        action="store_true",
+        help="Validate that all 5 container images and Dataflow Flex Template exist in remote registries/GCS.",
+    )
+    parser.add_argument(
+        "--template-bucket",
+        default=DEFAULT_TEMPLATE_GCS_BASE,
+        help=f"GCS bucket directory for Dataflow Flex Templates (default: {DEFAULT_TEMPLATE_GCS_BASE}).",
+    )
     args = parser.parse_args()
-    validate_release_version(args.tag_or_version)
+    validate_release_version(
+        tag_or_version=args.tag_or_version,
+        check_remote_artifacts=args.check_remote_artifacts,
+        template_gcs_base=args.template_bucket,
+    )
 
 
 if __name__ == "__main__":

--- a/deploy/scripts/validate_release_version.py
+++ b/deploy/scripts/validate_release_version.py
@@ -193,14 +193,25 @@ def validate_release_version(
             # A. Check container images in GCR/Artifact Registry
             for artifact, repo in ARTIFACT_IMAGE_MAP.items():
                 image_ref = f"{repo}:{target_version}"
-                cmd = [
-                    "gcloud",
-                    "container",
-                    "images",
-                    "describe",
-                    image_ref,
-                    "--format=json",
-                ]
+                if "pkg.dev" in repo:
+                    cmd = [
+                        "gcloud",
+                        "artifacts",
+                        "docker",
+                        "images",
+                        "describe",
+                        image_ref,
+                        "--format=json",
+                    ]
+                else:
+                    cmd = [
+                        "gcloud",
+                        "container",
+                        "images",
+                        "describe",
+                        image_ref,
+                        "--format=json",
+                    ]
                 res = subprocess.run(cmd, check=False, capture_output=True, text=True)
                 if res.returncode != 0:
                     detail = (

--- a/deploy/scripts/validate_release_version.py
+++ b/deploy/scripts/validate_release_version.py
@@ -45,6 +45,7 @@ USAGE:
 
 import argparse
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -183,38 +184,49 @@ def validate_release_version(
     # 5. Optional / CI: Validate remote release artifacts (images & GCS template)
     if check_remote_artifacts:
         print("\nValidating remote release artifacts exist...")
-
-        # A. Check container images in GCR/Artifact Registry
-        for artifact, repo in ARTIFACT_IMAGE_MAP.items():
-            image_ref = f"{repo}:{target_version}"
-            cmd = [
-                "gcloud",
-                "container",
-                "images",
-                "describe",
-                image_ref,
-                "--format=json",
-            ]
-            res = subprocess.run(cmd, check=False, capture_output=True, text=True)
-            if res.returncode != 0:
-                errors.append(
-                    f"Remote container image '{image_ref}' does not exist in registry."
-                )
-            else:
-                print(f"  [OK] Container Image ({artifact}): {image_ref}")
-
-        # B. Check Dataflow Flex Template spec in GCS
-        template_uri = (
-            f"{template_gcs_base.rstrip('/')}/ingestion-{target_version}.json"
-        )
-        cmd = ["gcloud", "storage", "ls", template_uri]
-        res = subprocess.run(cmd, check=False, capture_output=True, text=True)
-        if res.returncode != 0:
+        if not shutil.which("gcloud"):
             errors.append(
-                f"Dataflow Flex Template spec '{template_uri}' does not exist in GCS."
+                "'gcloud' CLI tool is required for remote artifact validation"
+                " but was not found in PATH."
             )
         else:
-            print(f"  [OK] Dataflow Flex Template: {template_uri}")
+            # A. Check container images in GCR/Artifact Registry
+            for artifact, repo in ARTIFACT_IMAGE_MAP.items():
+                image_ref = f"{repo}:{target_version}"
+                cmd = [
+                    "gcloud",
+                    "container",
+                    "images",
+                    "describe",
+                    image_ref,
+                    "--format=json",
+                ]
+                res = subprocess.run(cmd, check=False, capture_output=True, text=True)
+                if res.returncode != 0:
+                    detail = (
+                        f" Details: {res.stderr.strip()}" if res.stderr.strip() else ""
+                    )
+                    errors.append(
+                        f"Remote container image '{image_ref}' does not exist"
+                        f" in registry.{detail}"
+                    )
+                else:
+                    print(f"  [OK] Container Image ({artifact}): {image_ref}")
+
+            # B. Check Dataflow Flex Template spec in GCS
+            template_uri = (
+                f"{template_gcs_base.rstrip('/')}/ingestion-{target_version}.json"
+            )
+            cmd = ["gcloud", "storage", "ls", template_uri]
+            res = subprocess.run(cmd, check=False, capture_output=True, text=True)
+            if res.returncode != 0:
+                detail = f" Details: {res.stderr.strip()}" if res.stderr.strip() else ""
+                errors.append(
+                    f"Dataflow Flex Template spec '{template_uri}' does not"
+                    f" exist in GCS.{detail}"
+                )
+            else:
+                print(f"  [OK] Dataflow Flex Template: {template_uri}")
 
     if errors:
         print("\nRelease validation FAILED with the following error(s):")

--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -61,8 +61,39 @@ steps:
           git push origin "v$tag_version" --force
         fi
 
-  # 2. Build and publish all Python packages to TestPyPI
+  # 2. Cross-tag container images and stage Dataflow Flex Template JSON
+  - name: 'google/cloud-sdk:slim'
+    id: 'tag-release-artifacts'
+    entrypoint: 'bash'
+    env:
+      - 'TARGET_VERSION=${_TARGET_VERSION}'
+      - 'DEFAULT_SOURCE_TAG=${_DEFAULT_SOURCE_TAG}'
+      - 'SERVICES_TAG=${_SERVICES_TAG}'
+      - 'PREPROCESSOR_TAG=${_PREPROCESSOR_TAG}'
+      - 'POSTPROCESSOR_TAG=${_POSTPROCESSOR_TAG}'
+      - 'INGESTION_HELPER_TAG=${_INGESTION_HELPER_TAG}'
+      - 'DATAFLOW_TAG=${_DATAFLOW_TAG}'
+    args:
+      - '-c'
+      - |
+        set -eo pipefail
+        if [ -n "$$DEFAULT_SOURCE_TAG" ] || [ -n "$$SERVICES_TAG" ] || [ -n "$$PREPROCESSOR_TAG" ] || [ -n "$$POSTPROCESSOR_TAG" ] || [ -n "$$INGESTION_HELPER_TAG" ] || [ -n "$$DATAFLOW_TAG" ]; then
+          echo "Tagging release artifacts and staging Dataflow template for $$TARGET_VERSION..."
+          args=(--target-tag "$$TARGET_VERSION")
+          [ -n "$$DEFAULT_SOURCE_TAG" ] && args+=(--default-source-tag "$$DEFAULT_SOURCE_TAG")
+          [ -n "$$SERVICES_TAG" ] && args+=(--services-tag "$$SERVICES_TAG")
+          [ -n "$$PREPROCESSOR_TAG" ] && args+=(--preprocessor-tag "$$PREPROCESSOR_TAG")
+          [ -n "$$POSTPROCESSOR_TAG" ] && args+=(--postprocessor-tag "$$POSTPROCESSOR_TAG")
+          [ -n "$$INGESTION_HELPER_TAG" ] && args+=(--ingestion-helper-tag "$$INGESTION_HELPER_TAG")
+          [ -n "$$DATAFLOW_TAG" ] && args+=(--dataflow-tag "$$DATAFLOW_TAG")
+          python3 deploy/scripts/tag_release_artifacts.py "$${args[@]}"
+        else
+          echo "No artifact source tags provided; skipping container image and Dataflow template tagging."
+        fi
+
+  # 3. Build and publish all Python packages to TestPyPI
   - name: 'ghcr.io/astral-sh/uv:python3.12-trixie-slim'
+    id: 'publish-testpypi-packages'
     entrypoint: 'python3'
     secretEnv:
       - 'TEST_PYPI_TOKEN'
@@ -80,6 +111,12 @@ substitutions:
   _GITHUB_BRANCH: 'main'
   _GITHUB_COMMIT: ''
   _TARGET_VERSION: ''
+  _DEFAULT_SOURCE_TAG: ''
+  _SERVICES_TAG: ''
+  _PREPROCESSOR_TAG: ''
+  _POSTPROCESSOR_TAG: ''
+  _INGESTION_HELPER_TAG: ''
+  _DATAFLOW_TAG: ''
 
 availableSecrets:
   secretManager:

--- a/docs/release.md
+++ b/docs/release.md
@@ -32,41 +32,35 @@ The release process follows three sequential stages:
 
 ### Phase 1: Stage & Verify a Release Candidate (RC) in TestPyPI
 
-#### Step 0: Tag Candidate Images & Flex Template
-Ensure all core microservice images and the Dataflow flex template are built and tagged with the candidate version (e.g. `X.Y.ZrcN`):
-* `gcr.io/datcom-ci/datacommons-services:X.Y.ZrcN`
-* `gcr.io/datcom-ci/datacommons-data:X.Y.ZrcN`
-* `gcr.io/datcom-ci/datacommons-ingestion-helper:X.Y.ZrcN`
-* `gcr.io/datcom-ci/datacommons-aggregation-helper:X.Y.ZrcN`
-* `us-docker.pkg.dev/datcom-ci/gcr.io/dataflow-templates/ingestion:X.Y.ZrcN`
-* `gs://datcom-templates/templates/flex/ingestion-X.Y.ZrcN.json`
-
-*(Note: Future followups will extend Cloud Build to automate image tagging).*
-
 #### Step 1: Submit Staging Build (`deploy/staging.yaml`)
-Submit `deploy/staging.yaml` with your target RC version:
+Submit `deploy/staging.yaml` with your target RC version and artifact source tags:
 ```bash
-# Build off latest main
+# Example 1: Stage RC by specifying a default source baseline and overriding services commit:
 gcloud builds submit \
   --config deploy/staging.yaml \
-  --substitutions=_TARGET_VERSION="X.Y.ZrcN" \
+  --substitutions=_TARGET_VERSION="1.1.2rc1",_DEFAULT_SOURCE_TAG="1.1.1",_SERVICES_TAG="1574ed3-79627f8-e265a1d" \
   --project="datcom-ci" \
   .
 
-# Or build off a specific commit SHA (e.g. 8f9b2a1)
+# Example 2: Build off a specific commit SHA on datacommons repo:
 gcloud builds submit \
   --config deploy/staging.yaml \
-  --substitutions=_TARGET_VERSION="X.Y.ZrcN",_GITHUB_COMMIT="8f9b2a1" \
+  --substitutions=_TARGET_VERSION="1.1.2rc1",_GITHUB_COMMIT="8f9b2a1",_DEFAULT_SOURCE_TAG="1.1.1" \
   --project="datcom-ci" \
   .
 ```
 
 **What this step does:**
-* Clones the target commit into a clean build container.
-* Runs `apply_version_bump.py "X.Y.ZrcN"` to update `VERSION`, `packages/*/VERSION`, `infra/dcp/variables.tf`, and lock `datacommons-admin==X.Y.ZrcN`.
-* Creates a local commit containing these updated version files and force-pushes Git tag `vX.Y.ZrcN` to GitHub.
-  *(Note: Tag `vX.Y.ZrcN` on GitHub points directly to this commit so remote Terraform module fetches via `?ref=vX.Y.ZrcN` resolve `default = "X.Y.ZrcN"` in `variables.tf`, while branch `main` remains clean).*
-* Runs `publish_packages.py --target testpypi` to build and upload wheels to **TestPyPI** in topological order.
+1. Clones the target commit and runs `apply_version_bump.py "X.Y.ZrcN"` to update `VERSION`, `packages/*/VERSION`, `infra/dcp/variables.tf`, and lock `datacommons-admin==X.Y.ZrcN`.
+2. Creates a local commit and force-pushes Git tag `vX.Y.ZrcN` to GitHub (*`main` branch remains clean*).
+3. Runs [`tag_release_artifacts.py`](../deploy/scripts/tag_release_artifacts.py) to cross-tag all 5 container images and stage the Dataflow Flex Template JSON spec in GCS:
+   - `services`: `gcr.io/datcom-ci/datacommons-services:X.Y.ZrcN`
+   - `preprocessor`: `gcr.io/datcom-ci/datacommons-data:X.Y.ZrcN`
+   - `postprocessor`: `gcr.io/datcom-ci/datacommons-aggregation-helper:X.Y.ZrcN`
+   - `ingestion_helper`: `gcr.io/datcom-ci/datacommons-ingestion-helper:X.Y.ZrcN`
+   - `dataflow`: `us-docker.pkg.dev/datcom-ci/gcr.io/dataflow-templates/ingestion:X.Y.ZrcN`
+   - `flex_template`: `gs://datcom-templates/templates/flex/ingestion-X.Y.ZrcN.json` (pointing to `ingestion:X.Y.ZrcN`)
+4. Runs `publish_packages.py --target testpypi` to build and upload wheels to **TestPyPI** in topological order.
 
 #### Step 2: Verify Release Candidate on Staging
 - [ ] **TestPyPI Package Check:** Confirm wheels exist at `https://test.pypi.org/project/datacommons-cli/X.Y.ZrcN/`.
@@ -95,37 +89,30 @@ gcloud builds submit \
 Once the RC is verified on staging:
 
 #### Step 1: Submit Version Bump PR Generator (`deploy/bump_version.yaml`)
+Pass `_NEW_VERSION` and the verified `_PROMOTED_CANDIDATE_TAG`:
 ```bash
 gcloud builds submit \
   --config deploy/bump_version.yaml \
-  --substitutions=_NEW_VERSION="X.Y.Z" \
+  --substitutions=_NEW_VERSION="1.1.2",_PROMOTED_CANDIDATE_TAG="1.1.2rc1" \
   --project="datcom-ci" \
   .
 ```
 
 **What this step does:**
-* Clones `main` and checks out branch `chore/bump-version-X.Y.Z`.
-* Runs `apply_version_bump.py "X.Y.Z"` to update `VERSION`, `packages/*/VERSION`, `packages/datacommons-cli/pyproject.toml`, and `infra/dcp/variables.tf`.
-* Runs `uv lock` to update dependencies.
-* Commits changes, pushes the branch to GitHub, and opens a Pull Request against `main`.
+1. Runs [`tag_release_artifacts.py`](../deploy/scripts/tag_release_artifacts.py) promoting all candidate images and the Dataflow Flex Template spec from `1.1.2rc1` to production `1.1.2`.
+2. Clones `main` and checks out branch `chore/bump-version-1.1.2`.
+3. Runs `apply_version_bump.py "1.1.2"` to update `VERSION`, `packages/*/VERSION`, `packages/datacommons-cli/pyproject.toml`, and `infra/dcp/variables.tf`.
+4. Runs `uv lock` to update dependencies.
+5. Commits changes, pushes the branch to GitHub, and opens a Pull Request against `main`.
 
 #### Step 2: Review & Merge PR
-1. Locate the auto-created PR (e.g. `chore: bump version to X.Y.Z`) on GitHub.
-2. Verify that `VERSION`, `packages/*/VERSION`, `packages/datacommons-cli/pyproject.toml`, and `infra/dcp/variables.tf` are updated to `X.Y.Z`.
+1. Locate the auto-created PR (e.g. `chore: bump version to 1.1.2`) on GitHub.
+2. Verify that `VERSION`, `packages/*/VERSION`, `packages/datacommons-cli/pyproject.toml`, and `infra/dcp/variables.tf` are updated to `1.1.2`.
 3. Approve and merge the PR into `main`.
 
 ---
 
 ### Phase 3: Publish Production Release to PyPI
-
-#### Step 0: Tag Production Images & Flex Template
-Ensure all production container images and Dataflow flex template are tagged with the release version (`X.Y.Z`):
-* `gcr.io/datcom-ci/datacommons-services:X.Y.Z`
-* `gcr.io/datcom-ci/datacommons-data:X.Y.Z`
-* `gcr.io/datcom-ci/datacommons-ingestion-helper:X.Y.Z`
-* `gcr.io/datcom-ci/datacommons-aggregation-helper:X.Y.Z`
-* `us-docker.pkg.dev/datcom-ci/gcr.io/dataflow-templates/ingestion:X.Y.Z`
-* `gs://datcom-templates/templates/flex/ingestion-X.Y.Z.json`
 
 #### Step 1: Draft & Publish GitHub Release
 1. Navigate to [GitHub Releases](https://github.com/datacommonsorg/datacommons/releases).
@@ -139,11 +126,12 @@ Ensure all production container images and Dataflow flex template are tagged wit
 
 **What this step triggers (`deploy/release.yaml`):**
 * Cloud Build automatically runs `deploy/release.yaml` on tag push `vX.Y.Z`.
-* Runs `deploy/scripts/validate_release_version.py "vX.Y.Z"` to perform **strict read-only validation**:
+* Runs `deploy/scripts/validate_release_version.py "vX.Y.Z" --check-remote-artifacts` to perform **strict pre-publish validation**:
   - Asserts root `VERSION == X.Y.Z`.
   - Asserts all `packages/*/VERSION == X.Y.Z`.
   - Asserts `datacommons-cli/pyproject.toml` locks `datacommons-admin==X.Y.Z`.
   - Asserts `infra/dcp/variables.tf` defaults `dcp_version = "X.Y.Z"`.
+  - **Remote Verification:** Asserts all 5 container images exist in GCR / Artifact Registry and the Dataflow Flex Template exists in GCS at tag `X.Y.Z`.
 * Runs `deploy/scripts/publish_packages.py --target pypi` to build and upload wheels to **Official PyPI** in topological order.
 
 > [!TIP]

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,18 +10,18 @@ The release process follows three sequential stages:
 
 1. **Stage 1: Stage a Release Candidate (RC) in TestPyPI**
    - **Pipeline:** `deploy/staging.yaml`
-   - **Scripts:** [`apply_version_bump.py`](../deploy/scripts/apply_version_bump.py), [`publish_packages.py`](../deploy/scripts/publish_packages.py)
-   - **Action:** Run `deploy/staging.yaml` with your target candidate version (e.g. `X.Y.ZrcN`). The build ephemerally bumps version files in-container, pushes Git tag `vX.Y.ZrcN` to GitHub (*`main` branch remains untouched*), and publishes candidate wheels to **TestPyPI** for staging verification.
+   - **Scripts:** [`apply_version_bump.py`](../deploy/scripts/apply_version_bump.py), [`tag_release_artifacts.py`](../deploy/scripts/tag_release_artifacts.py), [`publish_packages.py`](../deploy/scripts/publish_packages.py)
+   - **Action:** Run `deploy/staging.yaml` with your target candidate version (e.g. `X.Y.ZrcN`) and artifact source tags. The build ephemerally bumps version files in-container, cross-tags the release container images and Dataflow Flex Template spec (see [`ARTIFACT_IMAGE_MAP`](../deploy/scripts/tag_release_artifacts.py)), pushes Git tag `vX.Y.ZrcN` to GitHub (*`main` branch remains untouched*), and publishes candidate wheels to **TestPyPI** for staging verification.
 
 2. **Stage 2: Open & Merge Version Bump PR**
    - **Pipeline:** `deploy/bump_version.yaml`
-   - **Scripts:** [`apply_version_bump.py`](../deploy/scripts/apply_version_bump.py)
-   - **Action:** Run `deploy/bump_version.yaml` with the target release version (e.g. `X.Y.Z`). The build opens an automated PR against `main` containing updated `VERSION` files, `infra/dcp/variables.tf`, and `uv.lock`. Review and merge the PR into `main`.
+   - **Scripts:** [`apply_version_bump.py`](../deploy/scripts/apply_version_bump.py), [`tag_release_artifacts.py`](../deploy/scripts/tag_release_artifacts.py)
+   - **Action:** Run `deploy/bump_version.yaml` with the target release version (e.g. `X.Y.Z`) and candidate tag (`_PROMOTED_CANDIDATE_TAG`). The build promotes candidate artifacts to production tags, and opens an automated PR against `main` containing updated `VERSION` files, `infra/dcp/variables.tf`, and `uv.lock`. Review and merge the PR into `main`.
 
 3. **Stage 3: Publish Official Production Release**
    - **Pipeline:** `deploy/release.yaml`
    - **Scripts:** [`validate_release_version.py`](../deploy/scripts/validate_release_version.py), [`publish_packages.py`](../deploy/scripts/publish_packages.py)
-   - **Action:** Create and publish a GitHub Release with tag `vX.Y.Z` on `main`. Cloud Build automatically triggers `deploy/release.yaml`, validates that committed files match `X.Y.Z`, and publishes official wheels to **PyPI**.
+   - **Action:** Create and publish a GitHub Release with tag `vX.Y.Z` on `main`. Cloud Build automatically triggers `deploy/release.yaml`, validates that committed files and remote release artifacts exist for `X.Y.Z`, and publishes official wheels to **PyPI**.
 
 > [!IMPORTANT]
 > **Package Build & Distribution Order:** Public packages are built and published in strict topological dependency order via [`deploy/scripts/publish_packages.py`](../deploy/scripts/publish_packages.py) (`datacommons-admin` before `datacommons-cli`), satisfying the `datacommons-admin==VERSION` requirement on PyPI and TestPyPI.
@@ -35,31 +35,36 @@ The release process follows three sequential stages:
 #### Step 1: Submit Staging Build (`deploy/staging.yaml`)
 Submit `deploy/staging.yaml` with your target RC version and artifact source tags:
 ```bash
-# Example 1: Stage RC by specifying a default source baseline and overriding services commit:
+# Example showing all available substitution parameters:
 gcloud builds submit \
   --config deploy/staging.yaml \
-  --substitutions=_TARGET_VERSION="1.1.2rc1",_DEFAULT_SOURCE_TAG="1.1.1",_SERVICES_TAG="1574ed3-79627f8-e265a1d" \
-  --project="datcom-ci" \
-  .
-
-# Example 2: Build off a specific commit SHA on datacommons repo:
-gcloud builds submit \
-  --config deploy/staging.yaml \
-  --substitutions=_TARGET_VERSION="1.1.2rc1",_GITHUB_COMMIT="8f9b2a1",_DEFAULT_SOURCE_TAG="1.1.1" \
+  --substitutions=\
+_TARGET_VERSION="1.1.2rc1",\
+_DEFAULT_SOURCE_TAG="1.1.1",\
+_SERVICES_TAG="1574ed3-79627f8-e265a1d",\
+_PREPROCESSOR_TAG="1.1.1",\
+_POSTPROCESSOR_TAG="1.1.1",\
+_INGESTION_HELPER_TAG="1.1.1",\
+_DATAFLOW_TAG="1.1.1",\
+_GITHUB_COMMIT="" \
   --project="datcom-ci" \
   .
 ```
 
+**Substitutions Reference:**
+* `_TARGET_VERSION`: The target candidate version tag (e.g. `1.1.2rc1`) [Required].
+* `_DEFAULT_SOURCE_TAG`: Baseline source tag inherited by all 5 container images and the Dataflow template unless overridden.
+* `_SERVICES_TAG`: Source tag or commit SHA for `datacommons-services`.
+* `_PREPROCESSOR_TAG`: Source tag for `datacommons-data` (preprocessor).
+* `_POSTPROCESSOR_TAG`: Source tag for `datacommons-aggregation-helper` (postprocessor).
+* `_INGESTION_HELPER_TAG`: Source tag for `datacommons-ingestion-helper`.
+* `_DATAFLOW_TAG`: Source tag for Dataflow worker image and GCS template spec.
+* `_GITHUB_COMMIT`: Optional commit SHA on datacommons repository (defaults to `_GITHUB_BRANCH` / `main`).
+
 **What this step does:**
 1. Clones the target commit and runs `apply_version_bump.py "X.Y.ZrcN"` to update `VERSION`, `packages/*/VERSION`, `infra/dcp/variables.tf`, and lock `datacommons-admin==X.Y.ZrcN`.
 2. Creates a local commit and force-pushes Git tag `vX.Y.ZrcN` to GitHub (*`main` branch remains clean*).
-3. Runs [`tag_release_artifacts.py`](../deploy/scripts/tag_release_artifacts.py) to cross-tag all 5 container images and stage the Dataflow Flex Template JSON spec in GCS:
-   - `services`: `gcr.io/datcom-ci/datacommons-services:X.Y.ZrcN`
-   - `preprocessor`: `gcr.io/datcom-ci/datacommons-data:X.Y.ZrcN`
-   - `postprocessor`: `gcr.io/datcom-ci/datacommons-aggregation-helper:X.Y.ZrcN`
-   - `ingestion_helper`: `gcr.io/datcom-ci/datacommons-ingestion-helper:X.Y.ZrcN`
-   - `dataflow`: `us-docker.pkg.dev/datcom-ci/gcr.io/dataflow-templates/ingestion:X.Y.ZrcN`
-   - `flex_template`: `gs://datcom-templates/templates/flex/ingestion-X.Y.ZrcN.json` (pointing to `ingestion:X.Y.ZrcN`)
+3. Runs [`tag_release_artifacts.py`](../deploy/scripts/tag_release_artifacts.py) to cross-tag all 5 container images and stage the rendered Dataflow Flex Template JSON spec in GCS.
 4. Runs `publish_packages.py --target testpypi` to build and upload wheels to **TestPyPI** in topological order.
 
 #### Step 2: Verify Release Candidate on Staging

--- a/docs/release.md
+++ b/docs/release.md
@@ -35,18 +35,9 @@ The release process follows three sequential stages:
 #### Step 1: Submit Staging Build (`deploy/staging.yaml`)
 Submit `deploy/staging.yaml` with your target RC version and artifact source tags:
 ```bash
-# Example showing all available substitution parameters:
 gcloud builds submit \
   --config deploy/staging.yaml \
-  --substitutions=\
-_TARGET_VERSION="1.1.2rc1",\
-_DEFAULT_SOURCE_TAG="1.1.1",\
-_SERVICES_TAG="1574ed3-79627f8-e265a1d",\
-_PREPROCESSOR_TAG="1.1.1",\
-_POSTPROCESSOR_TAG="1.1.1",\
-_INGESTION_HELPER_TAG="1.1.1",\
-_DATAFLOW_TAG="1.1.1",\
-_GITHUB_COMMIT="" \
+  --substitutions=_TARGET_VERSION="1.1.2rc1",_DEFAULT_SOURCE_TAG="1.1.1",_SERVICES_TAG="1574ed3-79627f8-e265a1d" \
   --project="datcom-ci" \
   .
 ```

--- a/tests/deploy_scripts/test_release_scripts.py
+++ b/tests/deploy_scripts/test_release_scripts.py
@@ -18,8 +18,10 @@ Tests cover:
   1. apply_version_bump.py - Single source of truth version bumper.
   2. validate_release_version.py - Pre-publish version consistency validator.
   3. publish_packages.py - Package builder and PyPI / TestPyPI distributor.
+  4. tag_release_artifacts.py - Multi-artifact release tagger and template stager.
 """
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -27,6 +29,7 @@ from unittest.mock import MagicMock
 import apply_version_bump as bumper
 import publish_packages as publisher
 import pytest
+import tag_release_artifacts as tagger
 import validate_release_version as validator
 
 # ==============================================================================
@@ -302,6 +305,60 @@ class TestValidateReleaseVersion:
             validator.validate_release_version("1.0.0")
         assert exc_info.value.code == 1
 
+    def test_validate_release_version_remote_artifacts_success(
+        self, mock_monorepo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """// Test: test_validate_release_version_remote_artifacts_success
+
+        // Situation: validate_release_version is called with --check-remote-artifacts
+        and all images and templates exist.
+        // Expectation: Validator passes cleanly without error.
+        """
+        monkeypatch.setattr(
+            subprocess, "run", lambda *args, **kwargs: MagicMock(returncode=0)
+        )
+        validator.validate_release_version("1.0.0", check_remote_artifacts=True)
+
+    def test_validate_release_version_remote_image_missing_fails(
+        self, mock_monorepo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """// Test: test_validate_release_version_remote_image_missing_fails
+
+        // Situation: validate_release_version is called with --check-remote-artifacts
+        and a container image does not exist in registry.
+        // Expectation: Validator aborts with exit code 1.
+        """
+
+        def mock_run(cmd, **kwargs):
+            if "container" in cmd and "images" in cmd:
+                return MagicMock(returncode=1)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        with pytest.raises(SystemExit) as exc_info:
+            validator.validate_release_version("1.0.0", check_remote_artifacts=True)
+        assert exc_info.value.code == 1
+
+    def test_validate_release_version_remote_template_missing_fails(
+        self, mock_monorepo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """// Test: test_validate_release_version_remote_template_missing_fails
+
+        // Situation: validate_release_version is called with --check-remote-artifacts
+        and the GCS template spec is missing.
+        // Expectation: Validator aborts with exit code 1.
+        """
+
+        def mock_run(cmd, **kwargs):
+            if "storage" in cmd and "ls" in cmd:
+                return MagicMock(returncode=1)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        with pytest.raises(SystemExit) as exc_info:
+            validator.validate_release_version("1.0.0", check_remote_artifacts=True)
+        assert exc_info.value.code == 1
+
 
 # ==============================================================================
 # Suite 3: publish_packages.py
@@ -503,3 +560,164 @@ class TestReleaseWorkflowContract:
         bumper.apply_version_bump(target_version)
         validator.validate_release_version(target_version)
         validator.validate_release_version(target_version.lstrip("v"))
+
+
+# ==============================================================================
+# Suite 5: tag_release_artifacts.py
+# ==============================================================================
+
+
+class TestTagReleaseArtifacts:
+    def test_tag_all_artifacts_dry_run_success(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """// Test: test_tag_all_artifacts_dry_run_success
+
+        // Situation: tag_all_artifacts is called with a default baseline and a
+        services override in dry-run mode.
+        // Expectation: All 5 images and the template are planned correctly and
+        displayed in output.
+        """
+        tagger.tag_all_artifacts(
+            target_tag="1.1.2rc1",
+            default_source_tag="1.1.1",
+            services_tag="1574ed3-79627f8-e265a1d",
+            dry_run=True,
+        )
+        captured = capsys.readouterr().out
+        assert "RELEASE ARTIFACT TAGGING PLAN -> Target: '1.1.2rc1'" in captured
+        assert "services          : 1574ed3-79627f8-e265a1d -> 1.1.2rc1" in captured
+        assert "preprocessor      : 1.1.1 -> 1.1.2rc1" in captured
+        assert "postprocessor     : 1.1.1 -> 1.1.2rc1" in captured
+        assert "ingestion_helper  : 1.1.1 -> 1.1.2rc1" in captured
+        assert "dataflow          : 1.1.1 -> 1.1.2rc1" in captured
+        assert "ingestion-1.1.1.json -> ingestion-1.1.2rc1.json" in captured
+        assert "[DRY-RUN]" in captured
+
+    def test_tag_all_artifacts_wholesale_promotion(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """// Test: test_tag_all_artifacts_wholesale_promotion
+
+        // Situation: tag_all_artifacts is called to promote RC candidate 1.1.2rc2 to
+        production 1.1.2.
+        // Expectation: All artifacts inherit 1.1.2rc2 as the source tag.
+        """
+        tagger.tag_all_artifacts(
+            target_tag="1.1.2",
+            default_source_tag="1.1.2rc2",
+            dry_run=True,
+        )
+        captured = capsys.readouterr().out
+        assert "services          : 1.1.2rc2 -> 1.1.2" in captured
+        assert "preprocessor      : 1.1.2rc2 -> 1.1.2" in captured
+        assert "postprocessor     : 1.1.2rc2 -> 1.1.2" in captured
+        assert "ingestion_helper  : 1.1.2rc2 -> 1.1.2" in captured
+        assert "dataflow          : 1.1.2rc2 -> 1.1.2" in captured
+
+    def test_tag_all_artifacts_missing_source_tag_aborts(self) -> None:
+        """// Test: test_tag_all_artifacts_missing_source_tag_aborts
+
+        // Situation: tag_all_artifacts is called without a default source tag and
+        missing individual overrides.
+        // Expectation: Script calls sys.exit reporting missing source tags.
+        """
+        with pytest.raises(SystemExit) as exc_info:
+            tagger.tag_all_artifacts(
+                target_tag="1.1.2rc1",
+                services_tag="1574ed3",
+            )
+        assert "Missing source tag for artifact(s)" in str(exc_info.value)
+
+    @pytest.mark.parametrize("malformed_target", ["foo", "1.2", "1.2.3.4.5", ""])
+    def test_tag_all_artifacts_malformed_target_tag_aborts(
+        self, malformed_target: str
+    ) -> None:
+        """// Test: test_tag_all_artifacts_malformed_target_tag_aborts
+
+        // Situation: tag_all_artifacts is called with an invalid/malformed target
+        tag.
+        // Expectation: Script calls sys.exit rejecting invalid version format.
+        """
+        with pytest.raises(SystemExit) as exc_info:
+            tagger.tag_all_artifacts(
+                target_tag=malformed_target,
+                default_source_tag="1.1.1",
+            )
+        assert "Invalid target tag format" in str(
+            exc_info.value
+        ) or "Target tag cannot be empty" in str(exc_info.value)
+
+    def test_stage_dataflow_template_mutates_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """// Test: test_stage_dataflow_template_mutates_json
+
+        // Situation: stage_dataflow_template executes gcloud storage cp to download
+        and upload.
+        // Expectation: The downloaded JSON has its 'image' key updated to the target
+        image repo:tag.
+        """
+        source_json = tmp_path / "ingestion-1.1.1.json"
+        source_json.write_text(
+            json.dumps(
+                {
+                    "image": (
+                        "us-docker.pkg.dev/datcom-ci/gcr.io/dataflow-templates/ingestion:1.1.1"
+                    ),
+                    "sdk_info": {"language": "PYTHON"},
+                },
+                indent=2,
+            )
+        )
+
+        uploaded_content = {}
+
+        def mock_gcloud_run(cmd, **kwargs):
+            if cmd[0] == "gcloud" and cmd[1] == "storage" and cmd[2] == "cp":
+                src = cmd[3]
+                dst = cmd[4]
+                if src.startswith("gs://"):
+                    Path(dst).write_text(source_json.read_text())
+                elif dst.startswith("gs://"):
+                    uploaded_content["data"] = json.loads(Path(src).read_text())
+                return MagicMock(returncode=0)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", mock_gcloud_run)
+
+        tagger.stage_dataflow_template(
+            gcs_base="gs://datcom-templates/templates/flex",
+            src_tag="1.1.1",
+            target_tag="1.1.2rc1",
+            dataflow_image_repo="us-docker.pkg.dev/datcom-ci/gcr.io/dataflow-templates/ingestion",
+            dry_run=False,
+        )
+
+        assert (
+            uploaded_content["data"]["image"]
+            == "us-docker.pkg.dev/datcom-ci/gcr.io/dataflow-templates/ingestion:1.1.2rc1"
+        )
+        assert uploaded_content["data"]["sdk_info"]["language"] == "PYTHON"
+
+    def test_tag_container_image_failure_aborts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """// Test: test_tag_container_image_failure_aborts
+
+        // Situation: gcloud container images add-tag fails with exit code 1.
+        // Expectation: Script calls sys.exit reporting the command failure.
+        """
+
+        def failing_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd, stderr="Image not found")
+
+        monkeypatch.setattr(subprocess, "run", failing_run)
+
+        with pytest.raises(SystemExit) as exc_info:
+            tagger.tag_container_image(
+                repo="gcr.io/datcom-ci/datacommons-services",
+                src_tag="missing-tag",
+                target_tag="1.1.2",
+            )
+        assert "Failed to tag image" in str(exc_info.value)

--- a/tests/deploy_scripts/test_release_scripts.py
+++ b/tests/deploy_scripts/test_release_scripts.py
@@ -22,6 +22,7 @@ Tests cover:
 """
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -355,6 +356,23 @@ class TestValidateReleaseVersion:
             return MagicMock(returncode=0)
 
         monkeypatch.setattr(subprocess, "run", mock_run)
+        with pytest.raises(SystemExit) as exc_info:
+            validator.validate_release_version("1.0.0", check_remote_artifacts=True)
+        assert exc_info.value.code == 1
+
+    def test_validate_release_version_missing_gcloud_fails(
+        self, mock_monorepo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """// Test: test_validate_release_version_missing_gcloud_fails
+
+        // Situation: check_remote_artifacts is True but gcloud is not installed.
+        // Expectation: Validator reports missing gcloud and exits with 1.
+        """
+        monkeypatch.setattr(
+            shutil,
+            "which",
+            lambda cmd: None if cmd == "gcloud" else "/usr/bin/" + cmd,
+        )
         with pytest.raises(SystemExit) as exc_info:
             validator.validate_release_version("1.0.0", check_remote_artifacts=True)
         assert exc_info.value.code == 1
@@ -721,3 +739,54 @@ class TestTagReleaseArtifacts:
                 target_tag="1.1.2",
             )
         assert "Failed to tag image" in str(exc_info.value)
+
+    def test_stage_dataflow_template_non_dict_json_aborts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """// Test: test_stage_dataflow_template_non_dict_json_aborts
+
+        // Situation: Downloaded template JSON is a list instead of a dictionary.
+        // Expectation: Script aborts with clear error message.
+        """
+        invalid_json = tmp_path / "invalid.json"
+        invalid_json.write_text(json.dumps(["item1", "item2"]))
+
+        def mock_gcloud_run(cmd, **kwargs):
+            if cmd[0] == "gcloud" and cmd[1] == "storage" and cmd[2] == "cp":
+                dst = cmd[4]
+                Path(dst).write_text(invalid_json.read_text())
+                return MagicMock(returncode=0)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", mock_gcloud_run)
+
+        with pytest.raises(SystemExit) as exc_info:
+            tagger.stage_dataflow_template(
+                gcs_base="gs://datcom-templates/templates/flex",
+                src_tag="1.1.1",
+                target_tag="1.1.2",
+                dataflow_image_repo="us-docker.pkg.dev/datcom-ci/gcr.io/dataflow-templates/ingestion",
+                dry_run=False,
+            )
+        assert "Template JSON root must be a dictionary object" in str(exc_info.value)
+
+    def test_tag_all_artifacts_missing_gcloud_aborts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """// Test: test_tag_all_artifacts_missing_gcloud_aborts
+
+        // Situation: tag_all_artifacts runs with dry_run=False but gcloud is not installed.
+        // Expectation: Script aborts reporting missing gcloud CLI.
+        """
+        monkeypatch.setattr(
+            shutil,
+            "which",
+            lambda cmd: None if cmd == "gcloud" else "/usr/bin/" + cmd,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            tagger.tag_all_artifacts(
+                target_tag="1.1.2",
+                default_source_tag="1.1.1",
+                dry_run=False,
+            )
+        assert "gcloud" in str(exc_info.value)

--- a/tests/deploy_scripts/test_release_scripts.py
+++ b/tests/deploy_scripts/test_release_scripts.py
@@ -331,7 +331,9 @@ class TestValidateReleaseVersion:
         """
 
         def mock_run(cmd, **kwargs):
-            if "container" in cmd and "images" in cmd:
+            if ("container" in cmd and "images" in cmd) or (
+                "artifacts" in cmd and "docker" in cmd
+            ):
                 return MagicMock(returncode=1)
             return MagicMock(returncode=0)
 
@@ -610,6 +612,8 @@ class TestTagReleaseArtifacts:
         assert "ingestion_helper  : 1.1.1 -> 1.1.2rc1" in captured
         assert "dataflow          : 1.1.1 -> 1.1.2rc1" in captured
         assert "ingestion-1.1.1.json -> ingestion-1.1.2rc1.json" in captured
+        assert "gcloud container images add-tag" in captured
+        assert "gcloud artifacts docker tags add" in captured
         assert "[DRY-RUN]" in captured
 
     def test_tag_all_artifacts_wholesale_promotion(


### PR DESCRIPTION
## What

Automates container image cross-tagging, Dataflow Flex Template staging, and pre-publish artifact validation across our release workflows.

## Why

Previously, cutting a staging RC or promoting an RC to production required manually running `gcloud` commands to tag 5 separate Docker images, downloading the Dataflow template JSON spec, updating its `"image"` reference, and re-uploading it to GCS. We also lacked a pre-flight check in `release.yaml` to ensure all remote artifacts existed before publishing wheels to PyPI.

## Changes

1. **`deploy/scripts/tag_release_artifacts.py`**:
   - Cross-tags the 5 core container images (`services`, `preprocessor`, `postprocessor`, `ingestion_helper`, `dataflow`).
   - Copies and updates the Dataflow Flex Template JSON spec in GCS (`gs://datcom-templates/templates/flex/ingestion-<TAG>.json`) so its internal `image` field points to the target Dataflow image tag.
   - Supports a default baseline source tag (`--default-source-tag`) with granular per-image overrides (`--services-tag`, etc.) and `--dry-run` inspection.

2. **`deploy/scripts/validate_release_version.py`**:
   - Added `--check-remote-artifacts` flag to verify that all 5 container images and the GCS Dataflow template exist before publishing packages.

3. **Cloud Build Pipelines**:
   - `deploy/staging.yaml`: Automates artifact tagging during staging candidate builds.
   - `deploy/bump_version.yaml`: Adds `_PROMOTED_CANDIDATE_TAG` substitution to promote verified candidate artifacts to production when opening the version bump PR.
   - `deploy/release.yaml`: Runs `validate_release_version.py --check-remote-artifacts` as Step 1 before PyPI package publishing.

4. **Tests & Docs**:
   - Added hermetic unit tests in `tests/deploy_scripts/test_release_scripts.py` (113 tests passing).
   - Updated `docs/release.md` runbook with the new workflows and commands.

## Testing

```bash
uv run pytest
uv run ruff check deploy/scripts/ tests/deploy_scripts/
python3 deploy/scripts/tag_release_artifacts.py --target-tag 1.1.2rc1 --default-source-tag 1.1.1 --services-tag 1574ed3 --dry-run
python3 deploy/scripts/validate_release_version.py 1.1.2
```